### PR TITLE
Custom CSS

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -481,41 +481,43 @@ function colormag_customize_register($wp_customize) {
       'settings' => 'colormag_primary_color'
    )));
 
-   // custom CSS setting
-   class COLORMAG_Custom_CSS_Control extends WP_Customize_Control {
+	if ( ! function_exists( 'wp_update_custom_css_post' ) ) {
+		// Custom CSS setting
+		class COLORMAG_Custom_CSS_Control extends WP_Customize_Control {
 
-      public $type = 'custom_css';
+			public $type = 'custom_css';
 
-      public function render_content() {
-      ?>
-         <label>
-            <span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
-            <textarea rows="5" style="width:100%;" <?php $this->link(); ?>><?php echo esc_textarea( $this->value() ); ?></textarea>
-         </label>
-      <?php
-      }
+			public function render_content() {
+			?>
+				<label>
+					<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+					<textarea rows="5" style="width:100%;" <?php $this->link(); ?>><?php echo esc_textarea( $this->value() ); ?></textarea>
+				</label>
+			<?php
+			}
 
-   }
+		}
 
-   $wp_customize->add_section('colormag_custom_css_setting', array(
-      'priority' => 9,
-      'title' => __('Custom CSS', 'colormag'),
-      'panel' => 'colormag_design_options'
-   ));
+		$wp_customize->add_section('colormag_custom_css_setting', array(
+			'priority' => 9,
+			'title' => __('Custom CSS', 'colormag'),
+			'panel' => 'colormag_design_options'
+		));
 
-   $wp_customize->add_setting('colormag_custom_css', array(
-      'default' => '',
-      'capability' => 'edit_theme_options',
-      'sanitize_callback' => 'wp_filter_nohtml_kses',
-      'sanitize_js_callback' => 'wp_filter_nohtml_kses'
-   ));
+		$wp_customize->add_setting('colormag_custom_css', array(
+			'default' => '',
+			'capability' => 'edit_theme_options',
+			'sanitize_callback' => 'wp_filter_nohtml_kses',
+			'sanitize_js_callback' => 'wp_filter_nohtml_kses'
+		));
 
-   $wp_customize->add_control(new COLORMAG_Custom_CSS_Control($wp_customize, 'colormag_custom_css', array(
-      'label' => __('Write your Custom CSS', 'colormag'),
-      'section' => 'colormag_custom_css_setting',
-      'settings' => 'colormag_custom_css'
-   )));
-   // End of the Design Options
+		$wp_customize->add_control(new COLORMAG_Custom_CSS_Control($wp_customize, 'colormag_custom_css', array(
+			'label' => __('Write your Custom CSS', 'colormag'),
+			'section' => 'colormag_custom_css_setting',
+			'settings' => 'colormag_custom_css'
+		)));
+	}
+	// End of the Design Options
 
    // Start of the Social Link Options
    $wp_customize->add_panel('colormag_social_links_options', array(

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -308,8 +308,8 @@ function colormag_custom_css() {
 <?php
 	}
 
-	$colormag_custom_css = get_theme_mod( 'colormag_custom_css', '' );
-	if( ! empty( $colormag_custom_css ) && ! function_exists( 'wp_update_custom_css_post' ) ) {
+	$colormag_custom_css = get_theme_mod( 'colormag_custom_css' );
+	if ( $colormag_custom_css && ! function_exists( 'wp_update_custom_css_post' ) ) {
 		echo '<!-- '.get_bloginfo('name').' Custom Styles -->';
 		?><style type="text/css"><?php echo $colormag_custom_css; ?></style><?php
 	}
@@ -719,22 +719,20 @@ add_action( 'after_setup_theme', 'colormag_site_icon_migrate' );
 /**
  * Migrate any existing theme CSS codes added in Customize Options to the core option added in WordPress 4.7
  */
-function colormag_customm_css_migrate() {
-	if ( get_option( 'colormag_custom_css_transfer' ) ) {
-		return;
-	}
+function colormag_custom_css_migrate() {
 
-	$theme_custom_css = get_theme_mod( 'colormag_custom_css', '' );
-	if ( ! empty( $theme_custom_css ) && function_exists( 'wp_update_custom_css_post' ) ) {
-		$wordpress_core_css = wp_get_custom_css(); // Preserve any CSS already added to the core option.
-		$return = wp_update_custom_css_post( $wordpress_core_css . $theme_custom_css );
-		if ( ! is_wp_error( $return ) ) {
-			// Set the transfer as complete
-			update_option( 'colormag_custom_css_transfer', 1 );
-			// Remove the old theme_mod option for the Custom CSS Box provided via theme
-			remove_theme_mod( 'colormag_custom_css' );
+	if ( function_exists( 'wp_update_custom_css_post' ) ) {
+		$custom_css = get_theme_mod( 'colormag_custom_css' );
+		if ( $custom_css ) {
+			$core_css = wp_get_custom_css(); // Preserve any CSS already added to the core option.
+			$return = wp_update_custom_css_post( $core_css . $custom_css );
+			if ( ! is_wp_error( $return ) ) {
+				// Remove the old theme_mod, so that the CSS is stored in only one place moving forward.
+				remove_theme_mod( 'colormag_custom_css' );
+			}
 		}
 	}
+
 }
 
 add_action( 'after_setup_theme', 'colormag_customm_css_migrate' );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -715,4 +715,27 @@ function colormag_site_icon_migrate() {
 }
 
 add_action( 'after_setup_theme', 'colormag_site_icon_migrate' );
+
+/**
+ * Migrate any existing theme CSS codes added in Customize Options to the core option added in WordPress 4.7
+ */
+function colormag_customm_css_migrate() {
+	if ( get_option( 'colormag_custom_css_transfer' ) ) {
+		return;
+	}
+
+	$theme_custom_css = get_theme_mod( 'colormag_custom_css', '' );
+	if ( ! empty( $theme_custom_css ) && function_exists( 'wp_update_custom_css_post' ) ) {
+		$wordpress_core_css = wp_get_custom_css(); // Preserve any CSS already added to the core option.
+		$return = wp_update_custom_css_post( $wordpress_core_css . $theme_custom_css );
+		if ( ! is_wp_error( $return ) ) {
+			// Set the transfer as complete
+			update_option( 'colormag_custom_css_transfer', 1 );
+			// Remove the old theme_mod option for the Custom CSS Box provided via theme
+			remove_theme_mod( 'colormag_custom_css' );
+		}
+	}
+}
+
+add_action( 'after_setup_theme', 'colormag_customm_css_migrate' );
 ?>

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -703,7 +703,7 @@ function colormag_site_icon_migrate() {
 	global $wp_version;
 	$image_url = get_theme_mod( 'colormag_favicon_upload', '' );
 
-	if ( ( $wp_version >= 4.3 ) || ( ! has_site_icon() && ! empty( $image_url ) ) ) {
+	if ( ( $wp_version >= 4.3 ) && ( ! has_site_icon() && ! empty( $image_url ) ) ) {
 		$customizer_site_icon_id = attachment_url_to_postid( $image_url );
 		update_option( 'site_icon', $customizer_site_icon_id );
 		// Set the transfer as complete.

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -309,7 +309,7 @@ function colormag_custom_css() {
 	}
 
 	$colormag_custom_css = get_theme_mod( 'colormag_custom_css', '' );
-	if( !empty( $colormag_custom_css ) ) {
+	if( ! empty( $colormag_custom_css ) && ! function_exists( 'wp_update_custom_css_post' ) ) {
 		echo '<!-- '.get_bloginfo('name').' Custom Styles -->';
 		?><style type="text/css"><?php echo $colormag_custom_css; ?></style><?php
 	}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -720,7 +720,6 @@ add_action( 'after_setup_theme', 'colormag_site_icon_migrate' );
  * Migrate any existing theme CSS codes added in Customize Options to the core option added in WordPress 4.7
  */
 function colormag_custom_css_migrate() {
-
 	if ( function_exists( 'wp_update_custom_css_post' ) ) {
 		$custom_css = get_theme_mod( 'colormag_custom_css' );
 		if ( $custom_css ) {
@@ -732,7 +731,6 @@ function colormag_custom_css_migrate() {
 			}
 		}
 	}
-
 }
 
 add_action( 'after_setup_theme', 'colormag_customm_css_migrate' );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -733,5 +733,5 @@ function colormag_custom_css_migrate() {
 	}
 }
 
-add_action( 'after_setup_theme', 'colormag_customm_css_migrate' );
+add_action( 'after_setup_theme', 'colormag_custom_css_migrate' );
 ?>

--- a/languages/colormag.pot
+++ b/languages/colormag.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GNU General Public License, version 3 (GPLv3).
 msgid ""
 msgstr ""
-"Project-Id-Version: ColorMag 1.1.4\n"
+"Project-Id-Version: ColorMag 1.1.6\n"
 "Report-Msgid-Bugs-To: themegrill@gmail.com\n"
-"POT-Creation-Date: 2016-09-02 10:27:00+00:00\n"
+"POT-Creation-Date: 2016-11-18 07:38:13+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -325,7 +325,7 @@ msgstr ""
 msgid "Color Options"
 msgstr ""
 
-#: inc/admin/class-colormag-admin.php:365 inc/customizer.php:466
+#: inc/admin/class-colormag-admin.php:365 inc/customizer.php:468
 msgid "Primary color option"
 msgstr ""
 
@@ -377,7 +377,7 @@ msgstr ""
 msgid "Change Read More Text"
 msgstr ""
 
-#: inc/admin/class-colormag-admin.php:425 inc/customizer.php:657
+#: inc/admin/class-colormag-admin.php:425 inc/customizer.php:661
 msgid "Related Posts"
 msgstr ""
 
@@ -453,7 +453,7 @@ msgstr ""
 msgid "TG: Featured Posts (Style 7)"
 msgstr ""
 
-#: inc/admin/class-colormag-admin.php:520 inc/customizer.php:715
+#: inc/admin/class-colormag-admin.php:520 inc/customizer.php:719
 msgid "Category Color Options"
 msgstr ""
 
@@ -565,230 +565,230 @@ msgstr ""
 msgid "Header Logo"
 msgstr ""
 
-#: inc/customizer.php:214
+#: inc/customizer.php:215
 msgid "Upload logo for your header"
 msgstr ""
 
-#: inc/customizer.php:227
+#: inc/customizer.php:229
 msgid "Choose the option that you want"
 msgstr ""
 
-#: inc/customizer.php:230 inc/customizer.php:768
+#: inc/customizer.php:232 inc/customizer.php:772
 msgid "Header Logo Only"
 msgstr ""
 
-#: inc/customizer.php:231 inc/customizer.php:769
+#: inc/customizer.php:233 inc/customizer.php:773
 msgid "Header Text Only"
 msgstr ""
 
-#: inc/customizer.php:232 inc/customizer.php:770
+#: inc/customizer.php:234 inc/customizer.php:774
 msgid "Show Both"
 msgstr ""
 
-#: inc/customizer.php:233 inc/customizer.php:771
+#: inc/customizer.php:235 inc/customizer.php:775
 msgid "Disable"
 msgstr ""
 
-#: inc/customizer.php:240
+#: inc/customizer.php:242
 msgid "Header Image Position"
 msgstr ""
 
-#: inc/customizer.php:252
+#: inc/customizer.php:254
 msgid "Header image display position"
 msgstr ""
 
-#: inc/customizer.php:255 inc/customizer.php:782
+#: inc/customizer.php:257 inc/customizer.php:786
 msgid "Display the Header image just above the site title/text."
 msgstr ""
 
-#: inc/customizer.php:256 inc/customizer.php:783
+#: inc/customizer.php:258 inc/customizer.php:787
 msgid ""
 "Default: Display the Header image between site title/text and the "
 "main/primary menu."
 msgstr ""
 
-#: inc/customizer.php:257 inc/customizer.php:784
+#: inc/customizer.php:259 inc/customizer.php:788
 msgid "Display the Header image below main/primary menu."
 msgstr ""
 
-#: inc/customizer.php:269
+#: inc/customizer.php:271
 msgid "Check to make header image link back to home page"
 msgstr ""
 
-#: inc/customizer.php:276
+#: inc/customizer.php:278
 msgid "Change the Design Settings from here as you want"
 msgstr ""
 
-#: inc/customizer.php:278
+#: inc/customizer.php:280
 msgid "Design Options"
 msgstr ""
 
-#: inc/customizer.php:284
+#: inc/customizer.php:286
 msgid "Front Page Settings"
 msgstr ""
 
-#: inc/customizer.php:295
+#: inc/customizer.php:297
 msgid "Check to hide blog posts/static page on front page"
 msgstr ""
 
-#: inc/customizer.php:302
+#: inc/customizer.php:304
 msgid "Site Layout"
 msgstr ""
 
-#: inc/customizer.php:314
+#: inc/customizer.php:316
 msgid "Choose your site layout. The change is reflected in whole site"
 msgstr ""
 
-#: inc/customizer.php:316 inc/customizer.php:795
+#: inc/customizer.php:318 inc/customizer.php:799
 msgid "Boxed Layout"
 msgstr ""
 
-#: inc/customizer.php:317 inc/customizer.php:796
+#: inc/customizer.php:319 inc/customizer.php:800
 msgid "Wide Layout"
 msgstr ""
 
-#: inc/customizer.php:387
+#: inc/customizer.php:389
 msgid "Default layout"
 msgstr ""
 
-#: inc/customizer.php:399
+#: inc/customizer.php:401
 msgid ""
 "Select default layout. This layout will be reflected in whole site "
 "archives, categories, search page etc. The layout for a single post and "
 "page can be controlled from below options"
 msgstr ""
 
-#: inc/customizer.php:413
+#: inc/customizer.php:415
 msgid "Default layout for pages only"
 msgstr ""
 
-#: inc/customizer.php:425
+#: inc/customizer.php:427
 msgid ""
 "Select default layout for pages. This layout will be reflected in all pages "
 "unless unique layout is set for specific page"
 msgstr ""
 
-#: inc/customizer.php:439
+#: inc/customizer.php:441
 msgid "Default layout for single posts only"
 msgstr ""
 
-#: inc/customizer.php:451
+#: inc/customizer.php:453
 msgid ""
 "Select default layout for single posts. This layout will be reflected in "
 "all single posts unless unique layout is set for specific post"
 msgstr ""
 
-#: inc/customizer.php:477
+#: inc/customizer.php:479
 msgid ""
 "This will reflect in links, buttons and many others. Choose a color to "
 "match your site"
 msgstr ""
 
-#: inc/customizer.php:500
+#: inc/customizer.php:502
 msgid "Custom CSS"
 msgstr ""
 
-#: inc/customizer.php:512
+#: inc/customizer.php:514
 msgid "Write your Custom CSS"
 msgstr ""
 
-#: inc/customizer.php:521
+#: inc/customizer.php:523
 msgid "Social Options"
 msgstr ""
 
-#: inc/customizer.php:522
+#: inc/customizer.php:524
 msgid "Change the Social Links settings from here as you want"
 msgstr ""
 
-#: inc/customizer.php:528
+#: inc/customizer.php:530
 msgid "Activate social links area"
 msgstr ""
 
-#: inc/customizer.php:540
+#: inc/customizer.php:542
 msgid "Check to activate social links area"
 msgstr ""
 
-#: inc/customizer.php:548 inc/header-functions.php:20
+#: inc/customizer.php:550 inc/header-functions.php:20
 msgid "Facebook"
 msgstr ""
 
-#: inc/customizer.php:553 inc/header-functions.php:21
+#: inc/customizer.php:555 inc/header-functions.php:21
 msgid "Twitter"
 msgstr ""
 
-#: inc/customizer.php:558 inc/header-functions.php:22
+#: inc/customizer.php:560 inc/header-functions.php:22
 msgid "Google-Plus"
 msgstr ""
 
-#: inc/customizer.php:563 inc/header-functions.php:23
+#: inc/customizer.php:565 inc/header-functions.php:23
 msgid "Instagram"
 msgstr ""
 
-#: inc/customizer.php:568 inc/header-functions.php:24
+#: inc/customizer.php:570 inc/header-functions.php:24
 msgid "Pinterest"
 msgstr ""
 
-#: inc/customizer.php:573 inc/header-functions.php:25
+#: inc/customizer.php:575 inc/header-functions.php:25
 msgid "YouTube"
 msgstr ""
 
-#: inc/customizer.php:603
+#: inc/customizer.php:605
 msgid "Check to open in new tab"
 msgstr ""
 
-#: inc/customizer.php:617
+#: inc/customizer.php:619
 msgid "Change the Additional Settings from here as you want"
 msgstr ""
 
-#: inc/customizer.php:619
+#: inc/customizer.php:621
 msgid "Additional Options"
 msgstr ""
 
-#: inc/customizer.php:625
+#: inc/customizer.php:628
 msgid "Activate favicon"
 msgstr ""
 
-#: inc/customizer.php:637
+#: inc/customizer.php:640
 msgid "Check to activate favicon. Upload favicon from below option"
 msgstr ""
 
-#: inc/customizer.php:649
+#: inc/customizer.php:652
 msgid "Upload favicon for your site"
 msgstr ""
 
-#: inc/customizer.php:669
+#: inc/customizer.php:673
 msgid "Check to activate the related posts"
 msgstr ""
 
-#: inc/customizer.php:682
+#: inc/customizer.php:686
 msgid "Related Posts Must Be Shown As:"
 msgstr ""
 
-#: inc/customizer.php:686 inc/customizer.php:756
+#: inc/customizer.php:690 inc/customizer.php:760
 msgid "Related Posts By Categories"
 msgstr ""
 
-#: inc/customizer.php:687 inc/customizer.php:757
+#: inc/customizer.php:691 inc/customizer.php:761
 msgid "Related Posts By Tags"
 msgstr ""
 
-#: inc/customizer.php:694
+#: inc/customizer.php:698
 msgid "Image Lightbox"
 msgstr ""
 
-#: inc/customizer.php:706
+#: inc/customizer.php:710
 msgid "Check to enable the lightbox for the featured images in single post"
 msgstr ""
 
-#: inc/customizer.php:717
+#: inc/customizer.php:721
 msgid "Change the color of each category items as you want."
 msgstr ""
 
-#: inc/customizer.php:722
+#: inc/customizer.php:726
 msgid "Category Color Settings"
 msgstr ""
 
-#: inc/customizer.php:744
+#: inc/customizer.php:748
 msgid "%s"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "colormag",
   "title": "Colormag",
-  "version": "1.1.3",
+  "version": "1.1.6",
   "homepage": "http://themegrill.com/themes/colormag",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,9 @@ and we will include it within the theme from next version update.
 /**********************************************************/
 
 == Changelog ==
+= Version TBD =
+* Feature - Migrated the Custom CSS code added in theme settings to Additional CSS section introduced in WordPress 4.7
+
 = Version 1.1.6 - 2016-11-18 =
 * Feature - Added the Custom Site Logo feature introduced in WordPress 4.5
 * Feature - Added support for Site Icon introduced in WordPress 4.3

--- a/readme.txt
+++ b/readme.txt
@@ -49,7 +49,7 @@ and we will include it within the theme from next version update.
 /**********************************************************/
 
 == Changelog ==
-= Version TBD =
+= Version 1.1.6 - 2016-11-18 =
 * Feature - Added the Custom Site Logo feature introduced in WordPress 4.5
 * Feature - Added support for Site Icon introduced in WordPress 4.3
 * Feature - Added compatibility for ThemeGrill Demo Importer plugin

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://themegrill.com/themes/colormag/
 Author: ThemeGrill
 Author URI: http://themegrill.com
 Description: ColorMag is a perfect responsive magazine style WordPress theme. Suitable for news, newspaper, magazine, publishing, business and any kind of sites. Get free support at http://themegrill.com/support-forum/ and check the demo at http://demo.themegrill.com/colormag/
-Version: 1.1.5
+Version: 1.1.6
 License: GNU General Public License, version 3 (GPLv3)
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
 Tags: one-column, two-columns, right-sidebar, left-sidebar, flexible-header, custom-header, custom-background, custom-menu, custom-colors, sticky-post, threaded-comments, translation-ready, featured-images, theme-options, post-formats, footer-widgets, blog, e-commerce, news


### PR DESCRIPTION
Migrate the Custom CSS codes added in the Custom CSS Box provided via the theme, in the Additional CSS section in Customize Options added since WordPress 4.7