### PR TITLE
Fix/color control

### DIFF
--- a/inc/customizer/custom-controls/color/class-colormag-color-control.php
+++ b/inc/customizer/custom-controls/color/class-colormag-color-control.php
@@ -29,6 +29,33 @@ class ColorMag_Color_Control extends ColorMag_Customize_Base_Additional_Control 
 	public $type = 'colormag-color';
 
 	/**
+	 * Enqueue control related scripts/styles.
+	 */
+	public function enqueue() {
+		parent::enqueue();
+
+		/**
+		 * Color picker strings from WordPress.
+		 *
+		 * Added since WordPress 5.5 has removed them causing alpha color not appearing issue.
+		 */
+		if ( version_compare( $GLOBALS['wp_version'], '5.5', '>=' ) ) {
+			wp_localize_script(
+				'wp-color-picker',
+				'wpColorPickerL10n',
+				array(
+					'clear'            => esc_html__( 'Clear', 'colormag' ),
+					'clearAriaLabel'   => esc_html__( 'Clear color', 'colormag' ),
+					'defaultString'    => esc_html__( 'Default', 'colormag' ),
+					'defaultAriaLabel' => esc_html__( 'Select default color', 'colormag' ),
+					'pick'             => esc_html__( 'Select Color', 'colormag' ),
+					'defaultLabel'     => esc_html__( 'Color value', 'colormag' ),
+				)
+			);
+		}
+	}
+
+	/**
 	 * Refresh the parameters passed to the JavaScript via JSON.
 	 *
 	 * @see WP_Customize_Control::to_json()
@@ -75,10 +102,10 @@ class ColorMag_Color_Control extends ColorMag_Customize_Base_Additional_Control 
 
 		<div class="customize-control-content">
 			<input class="colormag-color-picker-alpha color-picker-hex"
-			       type="text"
-			       data-alpha="true"
-			       data-default-color="{{ data.default }}"
-			       value="{{ data.value }}"
+				   type="text"
+				   data-alpha="true"
+				   data-default-color="{{ data.default }}"
+				   value="{{ data.value }}"
 			/>
 		</div>
 


### PR DESCRIPTION
# Changes proposed in this Pull Request
-I've fixed the Color Control option issue upon release of WP 5.5.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Checklist:
- [x] My code follows the WordPress' coding standards
- [x] I've checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have made perform test that prove my fix is effective or that my feature works
# Did you test this issue fix on all browser?
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
## Changelog entry
Fix - Color control issue upon WP 5.5 update.