### PR TITLE
Adds different customizer options for smooth loading of images on page reload and scroll.

### DIFF
--- a/SCSS/theme/_theme-style.scss
+++ b/SCSS/theme/_theme-style.scss
@@ -3584,3 +3584,39 @@ div#wp-custom-header:hover .wp-custom-header-video-button {
 .wp-custom-header-video-button.wp-custom-header-video-pause:before {
 	content: '\f04c';
 }
+
+/*--------------------------------------------------------------
+Reveal Images on Scroll Style
+--------------------------------------------------------------*/
+
+.tg-image-to-reveal-style-1 {
+	opacity: 0;
+	transform: translateY(5px);
+	transition: all .8s ease-out;
+}
+
+.tg-image-to-reveal-style-1--is-revealed {
+    opacity: 1;
+	transform: translateY(0);
+}
+
+
+.tg-image-to-reveal-style-2 {
+	opacity: 0;
+	transform: translateY(-5px);
+	transition: all .8s ease-out;
+}
+
+.tg-image-to-reveal-style-2--is-revealed {
+    opacity: 1;
+	transform: translateY(0);
+}
+
+.tg-image-to-reveal-style-3 {
+	opacity: 0;
+	transition: all .8s ease-out;
+}
+
+.tg-image-to-reveal-style-3--is-revealed {
+    opacity: 1;
+}

--- a/inc/customizer/class-colormag-customizer-register-sections-panels.php
+++ b/inc/customizer/class-colormag-customizer-register-sections-panels.php
@@ -150,6 +150,15 @@ class ColorMag_Customize_Register_Section_Panels extends ColorMag_Customize_Base
 				'priority' => 30,
 			),
 
+			// Images.
+			array(
+				'name'     => 'colormag_global_image_section',
+				'type'     => 'section',
+				'title'    => esc_html__( 'Images', 'colormag' ),
+				'panel'    => 'colormag_global_panel',
+				'priority' => 40,
+			),
+
 			array(
 				'name'     => 'colormag_site_layout_section',
 				'type'     => 'section',

--- a/inc/customizer/class-colormag-customizer.php
+++ b/inc/customizer/class-colormag-customizer.php
@@ -71,6 +71,7 @@ class ColorMag_Customizer {
 		require COLORMAG_CUSTOMIZER_DIR . '/options/global/class-colormag-customize-colors-options.php';
 		require COLORMAG_CUSTOMIZER_DIR . '/options/global/class-colormag-customize-background-options.php';
 		require COLORMAG_CUSTOMIZER_DIR . '/options/global/class-colormag-customize-layout-options.php';
+		require COLORMAG_CUSTOMIZER_DIR . '/options/global/class-colormag-customize-image-load-options.php';
 
 		// Front Page.
 		require COLORMAG_CUSTOMIZER_DIR . '/options/front-page/class-colormag-customize-front-page-options.php';

--- a/inc/customizer/options/global/class-colormag-customize-image-load-options.php
+++ b/inc/customizer/options/global/class-colormag-customize-image-load-options.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Class to include Image loading customize options.
+ *
+ * Class ColorMag_Customize_Image_Options
+ *
+ * @package    ThemeGrill
+ * @subpackage ColorMag
+ * @since      ColorMag 2.0.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class to include Image customize options.
+ *
+ * Class ColorMag_Customize_Image_Options
+ */
+class ColorMag_Customize_Image_Load_Options extends ColorMag_Customize_Base_Option {
+
+	/**
+	 * Include customize options.
+	 *
+	 * @param array                 $options      Customize options provided via the theme.
+	 * @param \WP_Customize_Manager $wp_customize Theme Customizer object.
+	 *
+	 * @return mixed|void Customizer options for registering panels, sections as well as controls.
+	 */
+	public function register_options( $options, $wp_customize ) {
+
+		$configs = array(
+
+			/**
+			 * Global image options.
+			 */
+			// Image loading option Heading Separator.
+			array(
+				'name'     => 'colormag__image_option_heading',
+				'type'     => 'control',
+				'control'  => 'colormag-title',
+				'label'    => esc_html__( 'Image loading options', 'colormag' ),
+				'section'  => 'colormag_global_image_section',
+				'priority' => 0,
+			),
+
+			// Image loading options.
+			array(
+				'name'      => 'colormag_image_loading_option',
+				'default'   => '1',
+				'type'      => 'control',
+				'control'   => 'radio',
+				'section'   => 'colormag_global_image_section',
+				'transport' => 'refresh',
+				'choices'   => array(
+					'style-1' => esc_html__( 'Style 1 (Fade in from bottom)', 'colormag' ),
+					'style-2' => esc_html__( 'Style 2 (Fade in from top)', 'colormag' ),
+					'style-3' => esc_html__( 'Style 3 (Fade in normally)', 'colormag' ),
+				),
+				'priority'  => 10,
+			),
+
+		);
+
+		$options = array_merge( $options, $configs );
+
+		return $options;
+	}
+
+}
+
+return new ColorMag_Customize_Image_Load_Options();

--- a/inc/enqueue-scripts.php
+++ b/inc/enqueue-scripts.php
@@ -81,6 +81,14 @@ function colormag_scripts_styles_method() {
 	// Theme custom JS.
 	wp_enqueue_script( 'colormag-custom', COLORMAG_JS_URL . '/colormag-custom' . $suffix . '.js', array( 'jquery' ), COLORMAG_THEME_VERSION, true );
 
+	// Theme reveal image on scroll JS.
+	wp_enqueue_script( 'colormag-reveal-on-scroll', COLORMAG_JS_URL . '/colormag-reveal-on-scroll' . $suffix . '.js', array( 'jquery' ), COLORMAG_THEME_VERSION, true );
+
+	$image_loading_styles = get_theme_mod( 'colormag_image_loading_option', 'style-1' );
+	if ( in_array( $image_loading_styles, array( 'style-1', 'style-2', 'style-3' ), true ) ) {
+		wp_localize_script( 'colormag-reveal-on-scroll', 'imageStyle', array( $image_loading_styles ) );
+	}
+
 	/**
 	 * Inline CSS for this theme.
 	 */

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -262,3 +262,27 @@ function colormag_body_class( $classes ) {
 }
 
 add_filter( 'body_class', 'colormag_body_class' );
+
+
+/**
+ * Filters the wp_get_attachment_image_attributes.
+ *
+ * Adds image-to-reveal-style-* classes to all the image element in the document.
+ *
+ * @param array $attr attributes of image element.
+ *
+ * @return array Image element with an added CSS class.
+ */
+function colormag_images_to_reveal_class( $attr ) {
+
+	$valid_styles     = array( 'style-1', 'style-2', 'style-3' );
+	$image_load_style = get_theme_mod( 'colormag_image_loading_option', 'style-1' );
+
+	if ( in_array( $image_load_style, $valid_styles, true ) && ! strpos( $attr['class'], 'tg-image-to-reveal-' . $image_load_style ) ) {
+		$attr['class'] .= ' tg-image-to-reveal-' . $image_load_style;
+	}
+
+	return $attr;
+}
+
+add_filter( 'wp_get_attachment_image_attributes', 'colormag_images_to_reveal_class', 10, 1 );

--- a/js/colormag-reveal-on-scroll.js
+++ b/js/colormag-reveal-on-scroll.js
@@ -1,0 +1,54 @@
+
+var revealImagesOnScroll = ( function() {
+
+	var images = document.querySelectorAll( 'img' );
+
+	var hideImagesInitially = function() {
+		images.forEach( el => {
+			if( ! el.classList.contains( 'tg-image-to-reveal-' + imageStyle[0] ) ) {
+				el.classList.add( 'tg-image-to-reveal-' + imageStyle[0] );
+			}
+			el.isRevealed = false;
+		});
+		images[images.length - 1].isLastItem = true;
+	};
+
+	var events = function() {
+		window.addEventListener( 'scroll', revealCaller );
+		window.addEventListener( 'load', revealCaller );
+	};
+
+	function revealCaller() {
+		images.forEach( el => {
+			if( el.isRevealed === false ) {
+				revealIfScrolledTo( el );
+			}
+		});
+	}
+
+	function revealIfScrolledTo( el ) {
+		if( window.scrollY + window.innerHeight > el.offsetTop ) {
+            var scrollPercent = ( el.getBoundingClientRect().top / window.innerHeight ) * 100;
+            if( scrollPercent < 70 ) {
+                el.classList.add( 'tg-image-to-reveal-' + imageStyle[0] + '--is-revealed' );
+                el.isRevealed = true;
+                if( el.isLastItem ){
+                    window.removeEventListener( 'scroll', revealCaller );
+					window.removeEventListener( 'load', revealCaller );
+                }
+            }
+        }
+	}
+
+	return {
+
+		init: function() {
+			hideImagesInitially();
+			events();
+		},
+
+	};
+
+}) ();
+
+revealImagesOnScroll.init();

--- a/style.css
+++ b/style.css
@@ -3452,6 +3452,47 @@ div#wp-custom-header:hover .wp-custom-header-video-button {
 	content: '\f04c';
 }
 
+/*--------------------------------------------------------------
+Reveal Images on Scroll Style
+--------------------------------------------------------------*/
+.tg-image-to-reveal-style-1 {
+	opacity: 0;
+	-webkit-transform: translateY(5px);
+	transform: translateY(5px);
+	-webkit-transition: all .8s ease-out;
+	transition: all .8s ease-out;
+}
+
+.tg-image-to-reveal-style-1--is-revealed {
+	opacity: 1;
+	-webkit-transform: translateY(0);
+	transform: translateY(0);
+}
+
+.tg-image-to-reveal-style-2 {
+	opacity: 0;
+	-webkit-transform: translateY(-5px);
+	transform: translateY(-5px);
+	-webkit-transition: all .8s ease-out;
+	transition: all .8s ease-out;
+}
+
+.tg-image-to-reveal-style-2--is-revealed {
+	opacity: 1;
+	-webkit-transform: translateY(0);
+	transform: translateY(0);
+}
+
+.tg-image-to-reveal-style-3 {
+	opacity: 0;
+	-webkit-transition: all .8s ease-out;
+	transition: all .8s ease-out;
+}
+
+.tg-image-to-reveal-style-3--is-revealed {
+	opacity: 1;
+}
+
 #masthead {
 	/*--------------------------------------------------------------
 	Clean Layout


### PR DESCRIPTION
### Changes proposed in this Pull Request
> Adds Customizer options for loading images smoothly, with three different simple animations.

### Type of change
- [ ] Code Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test the changes in this Pull Request:
1. Go to Appearance > Customize > Global >Images > Image loading options
2. Select different options available to load images.
3. Check on different Browsers as well

### Checklist:
- [x] My code follows WordPress' coding standards
- [x] I've checked to ensure there are no other open Pull Requests for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have made perform a test that proves my fix is effective or that my feature works

### Did you test this issue fix on all browsers?
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] opera