### PR TITLE
TT-1519-top-header-enlarge

### DIFF
--- a/assets/sass/components/top-bar/_breaking-news.scss
+++ b/assets/sass/components/top-bar/_breaking-news.scss
@@ -27,4 +27,5 @@
 	max-width: 240px;
 	overflow: hidden;
 	margin-left: 4px;
+    height: 20px;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,9 @@ and we will include it within the theme from next version update.
 /**********************************************************/
 
 == Changelog ==
+= Version TBD ==
+* Fix - Top header enlarge issue on page load.
+
 = Version - 2.1.4 - 2022-10-18 ==
 * Improvements - Header top bar design and CSS code refactor.
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -825,6 +825,7 @@ button:hover {
 	max-width: 240px;
 	overflow: hidden;
 	margin-right: 4px;
+	height: 20px;
 }
 
 .date-in-header {

--- a/style.css
+++ b/style.css
@@ -825,6 +825,7 @@ button:hover {
 	max-width: 240px;
 	overflow: hidden;
 	margin-left: 4px;
+	height: 20px;
 }
 
 .date-in-header {


### PR DESCRIPTION
What is done in this PR?

- Fixed top header enlarge issue on page load

How to test?

Enable breaking news option and load the page. The top header enlarge issue should be gone.