### PR TITLE
Fix: These strings are hardcoded and cannot be translated

### DIFF
--- a/inc/admin/views/dashbaord.php
+++ b/inc/admin/views/dashbaord.php
@@ -111,7 +111,7 @@ function import_button_html() {
 								}
 								?>
 								" target="_blank">
-									<?php echo $link_icon . 'Customize'; ?>
+									<?php echo $link_icon . esc_html__( 'Customize', 'colormag' ); ?>
 								</a>
 							</div>
 							<?php
@@ -174,7 +174,7 @@ function import_button_html() {
 									?>
 									" target="_blank">
 										<?php
-										echo $link_icon . 'Documentation';
+										echo $link_icon . esc_html__( 'Documentation', 'colormag' );
 										?>
 									</a>
 								</div>


### PR DESCRIPTION
Update dashbaord.php

Fix: [These strings are hardcoded and cannot be translated](https://wordpress.org/support/topic/these-strings-are-hardcoded-and-cannot-be-translated-4/)