### PR TITLE
CMAG-557 Dev - PHP 8.5 and WP 6.8+ compatibility

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,6 +12,10 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * PHP 8.0/8.1 polyfills — must load before any code that calls str_contains() etc.
+ */
+require get_template_directory() . '/inc/compat/php-polyfills.php';
 
 /**
  * Define constants.

--- a/inc/compat/php-polyfills.php
+++ b/inc/compat/php-polyfills.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * PHP version polyfills for backward and forward compatibility.
+ *
+ * Backports PHP 8.0+ functions to PHP 7.4, ensuring the theme runs without
+ * fatal errors on PHP 7.4 while remaining compatible with PHP 8.5+.
+ *
+ * @package    ThemeGrill
+ * @subpackage ColorMag
+ * @since      ColorMag 4.1.3
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// PHP 8.0: str_contains().
+if ( ! function_exists( 'str_contains' ) ) {
+	function str_contains( string $haystack, string $needle ): bool {
+		return '' === $needle || false !== strpos( $haystack, $needle );
+	}
+}
+
+// PHP 8.0: str_starts_with().
+if ( ! function_exists( 'str_starts_with' ) ) {
+	function str_starts_with( string $haystack, string $needle ): bool {
+		return 0 === strncmp( $haystack, $needle, strlen( $needle ) );
+	}
+}
+
+// PHP 8.0: str_ends_with().
+if ( ! function_exists( 'str_ends_with' ) ) {
+	function str_ends_with( string $haystack, string $needle ): bool {
+		return '' === $needle || ( '' !== $haystack && 0 === substr_compare( $haystack, $needle, -strlen( $needle ) ) );
+	}
+}
+
+// PHP 8.1: array_is_list().
+if ( ! function_exists( 'array_is_list' ) ) {
+	function array_is_list( array $arr ): bool {
+		if ( array() === $arr ) {
+			return true;
+		}
+		$next_key = 0;
+		foreach ( $arr as $k => $v ) {
+			if ( $k !== $next_key++ ) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/inc/core/class-colormag-enqueue-scripts.php
+++ b/inc/core/class-colormag-enqueue-scripts.php
@@ -247,10 +247,6 @@ if ( ! class_exists( 'ColorMag_Enqueue_Scripts' ) ) {
 			// jQuery Video JS.
 			wp_register_script( 'jquery-video', COLORMAG_JS_URL . '/jquery.video' . $suffix . '.js', array( 'jquery' ), COLORMAG_THEME_VERSION, true );
 
-			// HTML5Shiv for Lower IE versions.
-			wp_enqueue_script( 'html5', COLORMAG_JS_URL . '/html5shiv' . $suffix . '.js', array(), COLORMAG_THEME_VERSION );
-			wp_script_add_data( 'html5', 'conditional', 'lte IE 8' );
-
 			// Skip link focus fix JS enqueue.
 			wp_enqueue_script( 'colormag-skip-link-focus-fix', COLORMAG_JS_URL . '/skip-link-focus-fix' . $suffix . '.js', array(), COLORMAG_THEME_VERSION, true );
 		}

--- a/inc/widgets/abstract-colormag-widget.php
+++ b/inc/widgets/abstract-colormag-widget.php
@@ -26,14 +26,14 @@ abstract class ColorMag_Widget extends WP_Widget {
 	 *
 	 * @var string
 	 */
-	public $widget_cssclass;
+	public $widget_cssclass = '';
 
 	/**
 	 * Widget description.
 	 *
 	 * @var string
 	 */
-	public $widget_description;
+	public $widget_description = '';
 
 	/**
 	 * Widget ID.
@@ -47,7 +47,7 @@ abstract class ColorMag_Widget extends WP_Widget {
 	 *
 	 * @var string
 	 */
-	public $widget_name;
+	public $widget_name = '';
 
 	/**
 	 * Settings.


### PR DESCRIPTION
This PR Resolves deprecation warnings and errors that appear when running the themes on PHP 8.5 and WordPress 6.9. No visible changes for end users; the theme looks and behaves exactly the same.

As PHP and WordPress release newer versions, they phase out old approaches and flag them with warnings. Left unfixed, some of these warnings break page output entirely (as seen with the front-page error on PHP 8.5). This PR brings both themes in line with current PHP and WordPress standards.

### What was fixed
* Fatal error on PHP 7.4 caused by using a function that only exists in PHP 8.0+
* Front page breaking on PHP 8.5 due to a deprecation notice being output before the page could load
* WordPress 6.9 deprecation warning from an IE8 script that no browser has needed for years — removed cleanly
* Minor defensive improvements to internal widget classes to prevent warnings on newer PHP versions