### PR TITLE
CMAG-575 Tweak - Site title visibility settings turned to toggle

### DIFF
--- a/inc/customizer/options/header-builder/logo.php
+++ b/inc/customizer/options/header-builder/logo.php
@@ -1,5 +1,11 @@
 <?php
 
+// Legacy device-visibility arrays (devices where the element was shown). Used as the
+// per-install default for the new "Show on …" toggles, so existing sites keep their
+// previous configuration without needing a migration.
+$colormag_title_visibility   = (array) get_theme_mod( 'colormag_header_site_title_visibility', array( 'desktop', 'tablet', 'mobile' ) );
+$colormag_tagline_visibility = (array) get_theme_mod( 'colormag_header_site_tagline_visibility', array( 'desktop', 'tablet', 'mobile' ) );
+
 $options = array(
 	'colormag_header_site_identity_general_heading' => array(
 		'type'     => 'customind-title',
@@ -145,26 +151,45 @@ $options = array(
 						'colormag_enable_site_identity' => true,
 					),
 				),
-				'colormag_header_site_title_visibility' => [
-					'default'   => array(
-						'desktop',
-						'tablet',
-						'mobile',
-					),
-					'type'      => 'customind-visibility-button',
+				'colormag_header_site_title_visibility_heading' => array(
+					'type'      => 'customind-title',
 					'title'     => esc_html__( 'Site Title Visibility', 'colormag' ),
 					'section'   => 'colormag_header_builder_logo',
-					'multiple'  => true,
-					'priority'  => 20,
-					'choices'   => [
-						'desktop' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M16.5 2.5h-12a2.333 2.333 0 0 0-2.333 2.308v7.5A2.342 2.342 0 0 0 4.5 14.642h5.167v1.325H7.5a.834.834 0 0 0 0 1.666h6a.833.833 0 1 0 0-1.666h-2.167V14.65H16.5a2.342 2.342 0 0 0 2.333-2.333v-7.5A2.333 2.333 0 0 0 16.5 2.5Zm.667 9.833A.667.667 0 0 1 16.5 13h-12a.666.666 0 0 1-.667-.667v-7.5a.658.658 0 0 1 .667-.666h12a.659.659 0 0 1 .667.658v7.508Z"/></svg>',
-						'tablet'  => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M15.042 18.4H5.958a2.276 2.276 0 0 1-2.275-2.275V4a2.267 2.267 0 0 1 2.275-2.267h9.084A2.267 2.267 0 0 1 17.317 4v12.125a2.275 2.275 0 0 1-2.275 2.275ZM5.958 3.24A.758.758 0 0 0 5.2 4v12.125a.758.758 0 0 0 .758.758h9.084a.758.758 0 0 0 .758-.758V4a.758.758 0 0 0-.758-.759H5.958Zm5.3 11.367a.758.758 0 0 0-.758-.758.758.758 0 1 0 .767.758h-.009Z"/></svg>',
-						'mobile'  => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.292 18.333H6.709a2.275 2.275 0 0 1-2.267-2.275V3.941a2.267 2.267 0 0 1 2.267-2.274h7.583a2.267 2.267 0 0 1 2.267 2.266v12.134a2.275 2.275 0 0 1-2.267 2.266ZM6.709 3.192a.75.75 0 0 0-.75.75v12.125a.75.75 0 0 0 .75.758h7.583a.75.75 0 0 0 .75-.758V3.94a.75.75 0 0 0-.75-.75H6.709Zm4.558 11.358a.758.758 0 0 0-.758-.759.758.758 0 1 0 .766.759h-.008Z"/></svg>',
-					],
+					'priority'  => 19,
 					'condition' => array(
 						'colormag_enable_site_identity' => true,
 					),
-				],
+				),
+				'colormag_header_site_title_show_desktop' => array(
+					'default'   => in_array( 'desktop', $colormag_title_visibility, true ),
+					'type'      => 'customind-toggle',
+					'title'     => esc_html__( 'Show on Desktop', 'colormag' ),
+					'section'   => 'colormag_header_builder_logo',
+					'priority'  => 20,
+					'condition' => array(
+						'colormag_enable_site_identity' => true,
+					),
+				),
+				'colormag_header_site_title_show_tablet' => array(
+					'default'   => in_array( 'tablet', $colormag_title_visibility, true ),
+					'type'      => 'customind-toggle',
+					'title'     => esc_html__( 'Show on Tablet', 'colormag' ),
+					'section'   => 'colormag_header_builder_logo',
+					'priority'  => 21,
+					'condition' => array(
+						'colormag_enable_site_identity' => true,
+					),
+				),
+				'colormag_header_site_title_show_mobile' => array(
+					'default'   => in_array( 'mobile', $colormag_title_visibility, true ),
+					'type'      => 'customind-toggle',
+					'title'     => esc_html__( 'Show on Mobile', 'colormag' ),
+					'section'   => 'colormag_header_builder_logo',
+					'priority'  => 22,
+					'condition' => array(
+						'colormag_enable_site_identity' => true,
+					),
+				),
 			),
 		),
 		'collapsible'  => apply_filters( 'colormag_header_site_identity_accordion_collapsible', false ),
@@ -240,26 +265,45 @@ $options = array(
 						'colormag_enable_site_tagline' => true,
 					),
 				),
-				'colormag_header_site_tagline_visibility' => [
-					'default'   => array(
-						'desktop',
-						'tablet',
-						'mobile',
-					),
-					'type'      => 'customind-visibility-button',
-					'title'     => esc_html__( 'Site Tagline Visibility', 'colormag' ),
+				'colormag_header_site_tagline_visibility_heading' => array(
+					'type'      => 'customind-title',
+					'title'     => esc_html__( 'Tagline Visibility', 'colormag' ),
 					'section'   => 'colormag_header_builder_logo',
-					'priority'  => 20,
-					'multiple'  => true,
-					'choices'   => [
-						'desktop' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M16.5 2.5h-12a2.333 2.333 0 0 0-2.333 2.308v7.5A2.342 2.342 0 0 0 4.5 14.642h5.167v1.325H7.5a.834.834 0 0 0 0 1.666h6a.833.833 0 1 0 0-1.666h-2.167V14.65H16.5a2.342 2.342 0 0 0 2.333-2.333v-7.5A2.333 2.333 0 0 0 16.5 2.5Zm.667 9.833A.667.667 0 0 1 16.5 13h-12a.666.666 0 0 1-.667-.667v-7.5a.658.658 0 0 1 .667-.666h12a.659.659 0 0 1 .667.658v7.508Z"/></svg>',
-						'tablet'  => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M15.042 18.4H5.958a2.276 2.276 0 0 1-2.275-2.275V4a2.267 2.267 0 0 1 2.275-2.267h9.084A2.267 2.267 0 0 1 17.317 4v12.125a2.275 2.275 0 0 1-2.275 2.275ZM5.958 3.24A.758.758 0 0 0 5.2 4v12.125a.758.758 0 0 0 .758.758h9.084a.758.758 0 0 0 .758-.758V4a.758.758 0 0 0-.758-.759H5.958Zm5.3 11.367a.758.758 0 0 0-.758-.758.758.758 0 1 0 .767.758h-.009Z"/></svg>',
-						'mobile'  => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.292 18.333H6.709a2.275 2.275 0 0 1-2.267-2.275V3.941a2.267 2.267 0 0 1 2.267-2.274h7.583a2.267 2.267 0 0 1 2.267 2.266v12.134a2.275 2.275 0 0 1-2.267 2.266ZM6.709 3.192a.75.75 0 0 0-.75.75v12.125a.75.75 0 0 0 .75.758h7.583a.75.75 0 0 0 .75-.758V3.94a.75.75 0 0 0-.75-.75H6.709Zm4.558 11.358a.758.758 0 0 0-.758-.759.758.758 0 1 0 .766.759h-.008Z"/></svg>',
-					],
+					'priority'  => 19,
 					'condition' => array(
 						'colormag_enable_site_tagline' => true,
 					),
-				],
+				),
+				'colormag_header_site_tagline_show_desktop' => array(
+					'default'   => in_array( 'desktop', $colormag_tagline_visibility, true ),
+					'type'      => 'customind-toggle',
+					'title'     => esc_html__( 'Show on Desktop', 'colormag' ),
+					'section'   => 'colormag_header_builder_logo',
+					'priority'  => 20,
+					'condition' => array(
+						'colormag_enable_site_tagline' => true,
+					),
+				),
+				'colormag_header_site_tagline_show_tablet' => array(
+					'default'   => in_array( 'tablet', $colormag_tagline_visibility, true ),
+					'type'      => 'customind-toggle',
+					'title'     => esc_html__( 'Show on Tablet', 'colormag' ),
+					'section'   => 'colormag_header_builder_logo',
+					'priority'  => 21,
+					'condition' => array(
+						'colormag_enable_site_tagline' => true,
+					),
+				),
+				'colormag_header_site_tagline_show_mobile' => array(
+					'default'   => in_array( 'mobile', $colormag_tagline_visibility, true ),
+					'type'      => 'customind-toggle',
+					'title'     => esc_html__( 'Show on Mobile', 'colormag' ),
+					'section'   => 'colormag_header_builder_logo',
+					'priority'  => 22,
+					'condition' => array(
+						'colormag_enable_site_tagline' => true,
+					),
+				),
 			),
 		),
 		'collapsible'  => apply_filters( 'colormag_tagline_accordion_collapsible', false ),

--- a/template-parts/header-builder-elements/logo.php
+++ b/template-parts/header-builder-elements/logo.php
@@ -15,35 +15,28 @@ $description             = get_bloginfo( 'description', 'display' );
 $header_display_type     = get_theme_mod( 'colormag_header_logo_placement', 'header_text_only' );
 $site_identity_enable    = get_theme_mod( 'colormag_enable_site_identity', true );
 $site_tagline_enable     = get_theme_mod( 'colormag_enable_site_tagline', true );
-$site_title_visibility   = get_theme_mod(
-	'colormag_header_site_title_visibility',
-	array(
-		'desktop',
-		'tablet',
-		'mobile',
-	)
-);
-$site_tagline_visibility = get_theme_mod(
-	'colormag_header_site_tagline_visibility',
-	array(
-		'desktop',
-		'tablet',
-		'mobile',
-	)
-);
-
 $device_types = array( 'desktop', 'tablet', 'mobile' );
+
+// Legacy visibility arrays (devices where the element was shown). Used as the
+// backward-compatible default for the new per-device "Show on …" toggles, so
+// existing sites that configured the old control keep rendering identically.
+$legacy_title_visibility   = get_theme_mod( 'colormag_header_site_title_visibility', $device_types );
+$legacy_tagline_visibility = get_theme_mod( 'colormag_header_site_tagline_visibility', $device_types );
 
 $device_classes = array();
 foreach ( $device_types as $device ) {
-	if ( in_array( $device, $site_title_visibility, true ) ) {
+	$legacy_shown = in_array( $device, (array) $legacy_title_visibility, true );
+	$is_shown     = get_theme_mod( "colormag_header_site_title_show_$device", $legacy_shown );
+	if ( $is_shown ) {
 		$device_classes[] = "cm-title-show-$device";
 	}
 }
 
 $tagline_device_classes = array();
 foreach ( $device_types as $device ) {
-	if ( in_array( $device, $site_tagline_visibility, true ) ) {
+	$legacy_shown = in_array( $device, (array) $legacy_tagline_visibility, true );
+	$is_shown     = get_theme_mod( "colormag_header_site_tagline_show_$device", $legacy_shown );
+	if ( $is_shown ) {
 		$tagline_device_classes[] = "cm-tagline-show-$device";
 	}
 }


### PR DESCRIPTION
### Summary
This section in Site Title & Logo was for hiding the Site Title, but it took me a while to understand this, for normal users it might be confusion

Here, I think toggle would be much clearer with label as Hide in Desktop, Hide in Tablet, etc.

<img width="315" height="115" alt="image" src="https://github.com/user-attachments/assets/37fa1755-6c15-452b-a0bf-107c35cff082" />

### Changes Made
The Site Title visibility option has been changed to an individual toggle for clarity.