### PR TITLE
Fix: Block editor typography not reflecting Customizer fonts

### DIFF
--- a/inc/base/class-colormag-dynamic-css.php
+++ b/inc/base/class-colormag-dynamic-css.php
@@ -291,91 +291,8 @@ class ColorMag_Dynamic_CSS {
 		/**
 		 * Typography options.
 		 */
-		$base_typography_default                  = array(
-			'font-family'    => 'inherit',
-			'font-weight'    => 'regular',
-			'subsets'        => array( 'latin' ),
-			'font-size'      => array(
-				'desktop' => array(
-					'size' => '15',
-					'unit' => 'px',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'line-height'    => array(
-				'desktop' => array(
-					'size' => '1.6',
-					'unit' => '-',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'letter-spacing' => array(
-				'desktop' => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'font-style'     => 'normal',
-			'text-transform' => 'none',
-		);
-		$headings_typography_default              = array(
-			'font-family'    => 'inherit',
-			'font-weight'    => 'regular',
-			'subsets'        => array( 'latin' ),
-			'line-height'    => array(
-				'desktop' => array(
-					'size' => '1.2',
-					'unit' => '-',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'letter-spacing' => array(
-				'desktop' => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'font-style'     => 'normal',
-			'text-transform' => 'none',
-			'color'          => 'var(--cm-color-6)',
-		);
+		$base_typography_default                  = self::get_base_typography_default();
+		$headings_typography_default              = self::get_headings_typography_default();
 		$heading_h1_typography_default            = array(
 			'font-family'    => 'inherit',
 			'font-weight'    => 'regular',
@@ -1679,10 +1596,7 @@ class ColorMag_Dynamic_CSS {
 		$parse_css .= colormag_parse_css( '#207daf', $primary_color, $primary_color_css );
 
 		// Base typography.
-		$base_typography_default = array(
-			'font-family' => 'inherit',
-			'font-weight' => 'regular',
-		);
+		$base_typography_default = self::get_base_typography_default();
 		$base_typography         = get_theme_mod( 'colormag_base_typography', $base_typography_default );
 
 		$parse_css .= colormag_parse_typography_css(
@@ -1692,10 +1606,7 @@ class ColorMag_Dynamic_CSS {
 		);
 
 		// Headings typography.
-		$headings_typography_default = array(
-			'font-family' => 'inherit',
-			'font-weight' => 'regular',
-		);
+		$headings_typography_default = self::get_headings_typography_default();
 		$headings_typography         = get_theme_mod( 'colormag_headings_typography', $headings_typography_default );
 
 		$parse_css .= colormag_parse_typography_css(
@@ -1705,6 +1616,107 @@ class ColorMag_Dynamic_CSS {
 		);
 
 		return $parse_css;
+	}
+
+	/**
+	 * Default value for the `colormag_base_typography` theme mod.
+	 *
+	 * @return array
+	 */
+	private static function get_base_typography_default() {
+		return array(
+			'font-family'    => 'inherit',
+			'font-weight'    => 'regular',
+			'subsets'        => array( 'latin' ),
+			'font-size'      => array(
+				'desktop' => array(
+					'size' => '15',
+					'unit' => 'px',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'line-height'    => array(
+				'desktop' => array(
+					'size' => '1.6',
+					'unit' => '-',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'letter-spacing' => array(
+				'desktop' => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'font-style'     => 'normal',
+			'text-transform' => 'none',
+		);
+	}
+
+	/**
+	 * Default value for the `colormag_headings_typography` theme mod.
+	 *
+	 * @return array
+	 */
+	private static function get_headings_typography_default() {
+		return array(
+			'font-family'    => 'inherit',
+			'font-weight'    => 'regular',
+			'subsets'        => array( 'latin' ),
+			'line-height'    => array(
+				'desktop' => array(
+					'size' => '1.2',
+					'unit' => '-',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'letter-spacing' => array(
+				'desktop' => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'font-style'     => 'normal',
+			'text-transform' => 'none',
+			'color'          => 'var(--cm-color-6)',
+		);
 	}
 
 	/**

--- a/inc/base/class-colormag-dynamic-css.php
+++ b/inc/base/class-colormag-dynamic-css.php
@@ -293,249 +293,12 @@ class ColorMag_Dynamic_CSS {
 		 */
 		$base_typography_default                  = self::get_base_typography_default();
 		$headings_typography_default              = self::get_headings_typography_default();
-		$heading_h1_typography_default            = array(
-			'font-family'    => 'inherit',
-			'font-weight'    => 'regular',
-			'subsets'        => array( 'latin' ),
-			'font-size'      => array(
-				'desktop' => array(
-					'size' => '40',
-					'unit' => 'px',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'line-height'    => array(
-				'desktop' => array(
-					'size' => '1.2',
-					'unit' => '-',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'letter-spacing' => array(
-				'desktop' => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'font-style'     => 'normal',
-			'text-transform' => 'none',
-			'color'          => 'var(--cm-color-6)',
-		);
-		$heading_h2_typography_default            = array(
-			'font-family'    => 'inherit',
-			'font-weight'    => 'regular',
-			'subsets'        => array( 'latin' ),
-			'font-size'      => array(
-				'desktop' => array(
-					'size' => '32',
-					'unit' => 'px',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'line-height'    => array(
-				'desktop' => array(
-					'size' => '1.2',
-					'unit' => '-',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'letter-spacing' => array(
-				'desktop' => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'font-style'     => 'normal',
-			'text-transform' => 'none',
-			'color'          => 'var(--cm-color-6)',
-		);
-		$heading_h3_typography_default            = array(
-			'font-family'    => 'inherit',
-			'font-weight'    => 'regular',
-			'subsets'        => array( 'latin' ),
-			'font-size'      => array(
-				'desktop' => array(
-					'size' => '24',
-					'unit' => 'px',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'line-height'    => array(
-				'desktop' => array(
-					'size' => '1.2',
-					'unit' => '-',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'letter-spacing' => array(
-				'desktop' => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'font-style'     => 'normal',
-			'text-transform' => 'none',
-			'color'          => 'var(--cm-color-6)',
-		);
-		$heading_h4_typography_default            = array(
-			'font-size'   => array(
-				'desktop' => array(
-					'size' => '20',
-					'unit' => 'px',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'line-height' => array(
-				'desktop' => array(
-					'size' => '1.2',
-					'unit' => '-',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'color'          => 'var(--cm-color-6)',
-		);
-		$heading_h5_typography_default            = array(
-			'font-size'   => array(
-				'desktop' => array(
-					'size' => '18',
-					'unit' => 'px',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'line-height' => array(
-				'desktop' => array(
-					'size' => '1.2',
-					'unit' => '-',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'color'          => 'var(--cm-color-6)',
-		);
-		$heading_h6_typography_default            = array(
-			'font-size'   => array(
-				'desktop' => array(
-					'size' => '16',
-					'unit' => 'px',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'line-height' => array(
-				'desktop' => array(
-					'size' => '1.2',
-					'unit' => '-',
-				),
-				'tablet'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-				'mobile'  => array(
-					'size' => '',
-					'unit' => '',
-				),
-			),
-			'color'          => 'var(--cm-color-6)',
-		);
+		$heading_h1_typography_default            = self::get_heading_h1_typography_default();
+		$heading_h2_typography_default            = self::get_heading_h2_typography_default();
+		$heading_h3_typography_default            = self::get_heading_h3_typography_default();
+		$heading_h4_typography_default            = self::get_heading_h4_typography_default();
+		$heading_h5_typography_default            = self::get_heading_h5_typography_default();
+		$heading_h6_typography_default            = self::get_heading_h6_typography_default();
 		$site_title_typography_default       = array(
 			'font-family' => 'default',
 			'font-size'   => array(
@@ -1615,6 +1378,26 @@ class ColorMag_Dynamic_CSS {
 			'.editor-styles-wrapper h1, .editor-styles-wrapper h2, .editor-styles-wrapper h3, .editor-styles-wrapper h4, .editor-styles-wrapper h5, .editor-styles-wrapper h6'
 		);
 
+		// Per-level H1-H6 typography, layered on top of the general heading font, same as the front-end.
+		$heading_level_defaults = array(
+			'h1' => self::get_heading_h1_typography_default(),
+			'h2' => self::get_heading_h2_typography_default(),
+			'h3' => self::get_heading_h3_typography_default(),
+			'h4' => self::get_heading_h4_typography_default(),
+			'h5' => self::get_heading_h5_typography_default(),
+			'h6' => self::get_heading_h6_typography_default(),
+		);
+
+		foreach ( $heading_level_defaults as $level => $level_default ) {
+			$level_value = get_theme_mod( "colormag_{$level}_typography", $level_default );
+
+			$parse_css .= colormag_parse_typography_color_css(
+				$level_default,
+				$level_value,
+				".editor-styles-wrapper {$level}"
+			);
+		}
+
 		return $parse_css;
 	}
 
@@ -1716,6 +1499,297 @@ class ColorMag_Dynamic_CSS {
 			'font-style'     => 'normal',
 			'text-transform' => 'none',
 			'color'          => 'var(--cm-color-6)',
+		);
+	}
+
+	/**
+	 * Default value for the `colormag_h1_typography` theme mod.
+	 *
+	 * @return array
+	 */
+	private static function get_heading_h1_typography_default() {
+		return array(
+			'font-family'    => 'inherit',
+			'font-weight'    => 'regular',
+			'subsets'        => array( 'latin' ),
+			'font-size'      => array(
+				'desktop' => array(
+					'size' => '40',
+					'unit' => 'px',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'line-height'    => array(
+				'desktop' => array(
+					'size' => '1.2',
+					'unit' => '-',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'letter-spacing' => array(
+				'desktop' => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'font-style'     => 'normal',
+			'text-transform' => 'none',
+			'color'          => 'var(--cm-color-6)',
+		);
+	}
+
+	/**
+	 * Default value for the `colormag_h2_typography` theme mod.
+	 *
+	 * @return array
+	 */
+	private static function get_heading_h2_typography_default() {
+		return array(
+			'font-family'    => 'inherit',
+			'font-weight'    => 'regular',
+			'subsets'        => array( 'latin' ),
+			'font-size'      => array(
+				'desktop' => array(
+					'size' => '32',
+					'unit' => 'px',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'line-height'    => array(
+				'desktop' => array(
+					'size' => '1.2',
+					'unit' => '-',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'letter-spacing' => array(
+				'desktop' => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'font-style'     => 'normal',
+			'text-transform' => 'none',
+			'color'          => 'var(--cm-color-6)',
+		);
+	}
+
+	/**
+	 * Default value for the `colormag_h3_typography` theme mod.
+	 *
+	 * @return array
+	 */
+	private static function get_heading_h3_typography_default() {
+		return array(
+			'font-family'    => 'inherit',
+			'font-weight'    => 'regular',
+			'subsets'        => array( 'latin' ),
+			'font-size'      => array(
+				'desktop' => array(
+					'size' => '24',
+					'unit' => 'px',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'line-height'    => array(
+				'desktop' => array(
+					'size' => '1.2',
+					'unit' => '-',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'letter-spacing' => array(
+				'desktop' => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'font-style'     => 'normal',
+			'text-transform' => 'none',
+			'color'          => 'var(--cm-color-6)',
+		);
+	}
+
+	/**
+	 * Default value for the `colormag_h4_typography` theme mod.
+	 *
+	 * @return array
+	 */
+	private static function get_heading_h4_typography_default() {
+		return array(
+			'font-size'   => array(
+				'desktop' => array(
+					'size' => '20',
+					'unit' => 'px',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'line-height' => array(
+				'desktop' => array(
+					'size' => '1.2',
+					'unit' => '-',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'color'       => 'var(--cm-color-6)',
+		);
+	}
+
+	/**
+	 * Default value for the `colormag_h5_typography` theme mod.
+	 *
+	 * @return array
+	 */
+	private static function get_heading_h5_typography_default() {
+		return array(
+			'font-size'   => array(
+				'desktop' => array(
+					'size' => '18',
+					'unit' => 'px',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'line-height' => array(
+				'desktop' => array(
+					'size' => '1.2',
+					'unit' => '-',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'color'       => 'var(--cm-color-6)',
+		);
+	}
+
+	/**
+	 * Default value for the `colormag_h6_typography` theme mod.
+	 *
+	 * @return array
+	 */
+	private static function get_heading_h6_typography_default() {
+		return array(
+			'font-size'   => array(
+				'desktop' => array(
+					'size' => '16',
+					'unit' => 'px',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'line-height' => array(
+				'desktop' => array(
+					'size' => '1.2',
+					'unit' => '-',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '',
+				),
+			),
+			'color'       => 'var(--cm-color-6)',
 		);
 	}
 

--- a/inc/base/class-colormag-dynamic-css.php
+++ b/inc/base/class-colormag-dynamic-css.php
@@ -1678,6 +1678,32 @@ class ColorMag_Dynamic_CSS {
 
 		$parse_css .= colormag_parse_css( '#207daf', $primary_color, $primary_color_css );
 
+		// Base typography.
+		$base_typography_default = array(
+			'font-family' => 'inherit',
+			'font-weight' => 'regular',
+		);
+		$base_typography         = get_theme_mod( 'colormag_base_typography', $base_typography_default );
+
+		$parse_css .= colormag_parse_typography_css(
+			$base_typography_default,
+			$base_typography,
+			'.editor-styles-wrapper'
+		);
+
+		// Headings typography.
+		$headings_typography_default = array(
+			'font-family' => 'inherit',
+			'font-weight' => 'regular',
+		);
+		$headings_typography         = get_theme_mod( 'colormag_headings_typography', $headings_typography_default );
+
+		$parse_css .= colormag_parse_typography_css(
+			$headings_typography_default,
+			$headings_typography,
+			'.editor-styles-wrapper h1, .editor-styles-wrapper h2, .editor-styles-wrapper h3, .editor-styles-wrapper h4, .editor-styles-wrapper h5, .editor-styles-wrapper h6'
+		);
+
 		return $parse_css;
 	}
 

--- a/inc/core/class-colormag-enqueue-scripts.php
+++ b/inc/core/class-colormag-enqueue-scripts.php
@@ -108,56 +108,7 @@ if ( ! class_exists( 'ColorMag_Enqueue_Scripts' ) ) {
 			// Local Google fonts locally.
 			$host_fonts_locally = get_theme_mod( 'colormag_load_google_fonts_locally', false );
 
-			$typography_ids = apply_filters(
-				'colormag_enqueue_scripts_typography_ids',
-				array(
-					'colormag_blog_post_title_typography',
-					'colormag_single_post_title_typography',
-					'colormag_mobile_menu_typography',
-					'colormag_primary_menu_typography',
-					'colormag_site_tagline_typography',
-					'colormag_site_title_typography',
-					'colormag_h6_typography',
-					'colormag_h5_typography',
-					'colormag_h4_typography',
-					'colormag_h3_typography',
-					'colormag_h2_typography',
-					'colormag_h1_typography',
-					'colormag_headings_typography',
-					'colormag_base_typography',
-					'colormag_footer_copyright_typography',
-					'colormag_footer_menu_typography',
-					'colormag_footer_widget_1_title_typography',
-					'colormag_footer_widget_1_content_typography',
-					'colormag_footer_widget_2_title_typography',
-					'colormag_footer_widget_2_content_typography',
-					'colormag_footer_widget_3_title_typography',
-					'colormag_footer_widget_3_content_typography',
-					'colormag_footer_widget_4_title_typography',
-					'colormag_footer_widget_4_content_typography',
-					'colormag_footer_widget_5_title_typography',
-					'colormag_footer_widget_5_content_typography',
-					'colormag_footer_widget_6_title_typography',
-					'colormag_footer_widget_6_content_typography',
-					'colormag_footer_widget_7_title_typography',
-					'colormag_footer_widget_7_content_typography',
-					'colormag_primary_sub_menu_typography',
-					'colormag_mobile_sub_menu_typography',
-					'colormag_date_typography',
-					'colormag_header_site_title_typography',
-					'colormag_header_site_tagline_typography',
-					'colormag_header_mobile_menu_typography',
-					'colormag_news_ticker_typography',
-					'colormag_header_primary_menu_typography',
-					'colormag_header_primary_sub_menu_typography',
-					'colormag_header_secondary_menu_typography',
-					'colormag_header_secondary_sub_menu_typography',
-					'colormag_widget_1_title_typography',
-					'colormag_widget_1_content_typography',
-					'colormag_widget_2_title_typography',
-					'colormag_widget_2_content_typography',
-				)
-			);
+			$typography_ids = $this->get_typography_ids();
 
 			$google_fonts_url = \Customind\Core\get_google_fonts_url_by_ids( $typography_ids, $host_fonts_locally );
 
@@ -251,6 +202,67 @@ if ( ! class_exists( 'ColorMag_Enqueue_Scripts' ) ) {
 			wp_enqueue_script( 'colormag-skip-link-focus-fix', COLORMAG_JS_URL . '/skip-link-focus-fix' . $suffix . '.js', array(), COLORMAG_THEME_VERSION, true );
 		}
 
+		/**
+		 * Theme mod IDs whose typography values should be loaded as Google Fonts.
+		 *
+		 * Shared between the front-end and the block editor, so both always load
+		 * the exact same set of configured fonts.
+		 *
+		 * @return array
+		 */
+		private function get_typography_ids() {
+			return apply_filters(
+				'colormag_enqueue_scripts_typography_ids',
+				array(
+					'colormag_blog_post_title_typography',
+					'colormag_single_post_title_typography',
+					'colormag_mobile_menu_typography',
+					'colormag_primary_menu_typography',
+					'colormag_site_tagline_typography',
+					'colormag_site_title_typography',
+					'colormag_h6_typography',
+					'colormag_h5_typography',
+					'colormag_h4_typography',
+					'colormag_h3_typography',
+					'colormag_h2_typography',
+					'colormag_h1_typography',
+					'colormag_headings_typography',
+					'colormag_base_typography',
+					'colormag_footer_copyright_typography',
+					'colormag_footer_menu_typography',
+					'colormag_footer_widget_1_title_typography',
+					'colormag_footer_widget_1_content_typography',
+					'colormag_footer_widget_2_title_typography',
+					'colormag_footer_widget_2_content_typography',
+					'colormag_footer_widget_3_title_typography',
+					'colormag_footer_widget_3_content_typography',
+					'colormag_footer_widget_4_title_typography',
+					'colormag_footer_widget_4_content_typography',
+					'colormag_footer_widget_5_title_typography',
+					'colormag_footer_widget_5_content_typography',
+					'colormag_footer_widget_6_title_typography',
+					'colormag_footer_widget_6_content_typography',
+					'colormag_footer_widget_7_title_typography',
+					'colormag_footer_widget_7_content_typography',
+					'colormag_primary_sub_menu_typography',
+					'colormag_mobile_sub_menu_typography',
+					'colormag_date_typography',
+					'colormag_header_site_title_typography',
+					'colormag_header_site_tagline_typography',
+					'colormag_header_mobile_menu_typography',
+					'colormag_news_ticker_typography',
+					'colormag_header_primary_menu_typography',
+					'colormag_header_primary_sub_menu_typography',
+					'colormag_header_secondary_menu_typography',
+					'colormag_header_secondary_sub_menu_typography',
+					'colormag_widget_1_title_typography',
+					'colormag_widget_1_content_typography',
+					'colormag_widget_2_title_typography',
+					'colormag_widget_2_content_typography',
+				)
+			);
+		}
+
 		public function customize_js() {
 
 			wp_enqueue_script(
@@ -273,13 +285,10 @@ if ( ! class_exists( 'ColorMag_Enqueue_Scripts' ) ) {
 				return;
 			}
 
-			// Load the configured Heading/Body Google Fonts instead of the static "Open Sans" fallback.
+			// Load the same configured Google Fonts as the front-end instead of the static "Open Sans" fallback.
 			$host_fonts_locally      = get_theme_mod( 'colormag_load_google_fonts_locally', false );
 			$editor_google_fonts_url = \Customind\Core\get_google_fonts_url_by_ids(
-				array(
-					'colormag_headings_typography',
-					'colormag_base_typography',
-				),
+				$this->get_typography_ids(),
 				$host_fonts_locally
 			);
 

--- a/inc/core/class-colormag-enqueue-scripts.php
+++ b/inc/core/class-colormag-enqueue-scripts.php
@@ -273,7 +273,19 @@ if ( ! class_exists( 'ColorMag_Enqueue_Scripts' ) ) {
 				return;
 			}
 
-			if ( ! get_theme_mod( 'colormag_load_google_fonts_locally', false ) ) {
+			// Load the configured Heading/Body Google Fonts instead of the static "Open Sans" fallback.
+			$host_fonts_locally      = get_theme_mod( 'colormag_load_google_fonts_locally', false );
+			$editor_google_fonts_url = \Customind\Core\get_google_fonts_url_by_ids(
+				array(
+					'colormag_headings_typography',
+					'colormag_base_typography',
+				),
+				$host_fonts_locally
+			);
+
+			if ( $editor_google_fonts_url ) {
+				wp_enqueue_style( 'colormag-editor-googlefonts', $editor_google_fonts_url, array(), COLORMAG_THEME_VERSION );
+			} elseif ( ! $host_fonts_locally ) {
 				wp_enqueue_style( 'colormag-editor-googlefonts', '//fonts.googleapis.com/css?family=Open+Sans:400,600', array(), COLORMAG_THEME_VERSION );
 			}
 			wp_enqueue_style( 'colormag-block-editor-styles', get_template_directory_uri() . '/style-editor-block.css', array(), COLORMAG_THEME_VERSION );

--- a/inc/customizer/class-colormag-customizer.php
+++ b/inc/customizer/class-colormag-customizer.php
@@ -32,7 +32,8 @@ class ColorMag_Customizer {
 		// Include the required files for Customize option.
 		add_action( 'customize_register', array( $this, 'customize_options_file_include' ), 1 );
 
-		add_action( 'enqueue_block_editor_assets', array( $this, 'editor_dynamic_css' ) );
+		// Priority 20 so the style handle is already registered by colormag_block_editor_styles().
+		add_action( 'enqueue_block_assets', array( $this, 'editor_dynamic_css' ), 20 );
 
 		if ( get_theme_mod( 'colormag_enable_builder', false ) || colormag_maybe_enable_builder() ) {
 			add_filter( 'customizer_widgets_section_args', [ $this, 'modify_widgets_panel' ], 10, 3 );
@@ -175,6 +176,10 @@ class ColorMag_Customizer {
 	}
 
 	public function editor_dynamic_css() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		wp_add_inline_style( 'colormag-block-editor-styles', ColorMag_Dynamic_CSS::colormag_editor_block_css() );
 	}
 }


### PR DESCRIPTION
Jira: https://themegrill.atlassian.net/browse/MZB-742

## Summary
The block editor canvas never reflected the actual fonts configured under Customizer > Typography (global Heading, global Body, or per-level H1-H6 overrides). It always showed a static, hardcoded "Open Sans" instead, while the front-end and the Customizer live preview both rendered correctly. This made the editor an unreliable preview for any block whose typography control is left on "Default" (e.g. Magazine Blocks' Post Title / Highlighted Post Title controls), and is what MZB-742 reported.

## Root cause
1. `colormag_block_editor_styles()` (hooked on `enqueue_block_assets`, priority 1) always enqueued a static, hardcoded Google Fonts URL for "Open Sans" instead of the fonts actually configured in the Customizer.
2. `colormag_editor_block_css()` never generated any typography CSS for the editor at all — only CSS custom properties for the primary color.
3. `editor_dynamic_css()` (which attaches inline CSS to the `colormag-block-editor-styles` handle) was hooked to `enqueue_block_editor_assets`, which fires *before* `enqueue_block_assets` registers that handle — so `wp_add_inline_style()` was silently failing on every load, even for the primary-color CSS that already existed.
4. Even after fixing 1-3, per-level H1-H6 font overrides (`colormag_h1_typography`..`colormag_h6_typography`) were still not reflected in the editor, and even when the CSS rule was corrected, the actual font *file* for that override was never loaded into the editor (same class of bug, recurring for a narrower case).

## Changes
- `colormag_block_editor_styles()`: enqueue the real configured Google Fonts via the existing `get_google_fonts_url_by_ids()` helper, reusing the exact same typography ID list the front-end already uses (extracted into a shared `get_typography_ids()`), falling back to the static "Open Sans" link only when no custom font is configured (preserves existing behavior for untouched installs).
- `colormag_editor_block_css()`: generate real typography CSS for `.editor-styles-wrapper` (body), the general heading rule, and each individual H1-H6 override (layered in the same cascade order as the front-end), from the same saved Customizer values.
- `editor_dynamic_css()`: moved to `enqueue_block_assets` at priority 20 (after the style handle is registered) and added an `is_admin()` guard so it never runs on the front-end.
- Extracted every previously-inline default-value array (`colormag_base_typography`, `colormag_headings_typography`, `colormag_h1_typography`..`colormag_h6_typography`) into private getters, reused by both `render_output()` (front-end) and `colormag_editor_block_css()` (editor) — single source of truth instead of duplicated, partial copies.

## Known limitation / follow-up
This is a targeted fix for the typography controls that exist today (global Heading/Body + H1-H6 overrides), not a general editor/front-end style sync mechanism. If new typography-bearing controls are added to the front-end in the future, `colormag_editor_block_css()` will need to be updated to match, or the same class of bug will resurface for that new control.

A more robust long-term fix would take the entire front-end CSS output (`ColorMag_Dynamic_CSS::render_output()`), rewrite every selector to be scoped under `.editor-styles-wrapper`, and inject that into the editor instead of hand-maintaining a parallel typography-only generator — that would make *any* future front-end style change automatically available in the editor with no additional code. That's a meaningfully bigger, riskier change (needs a real CSS selector-rewriting step, not a blind string prefix, and pulls in a lot of front-end-only CSS such as sticky header/menu/footer widget rules that were never designed to render inside the editor's DOM and could have unpredictable effects on the editor canvas), so it's out of scope for this bug-fix PR. Flagging it here for awareness/backlog rather than attempting it now.

## Test cases

**Setup used for all cases below:** Customizer > Global > Typography, with a distinct Google Font set for Heading vs. Body (e.g. Heading = "Cedarville Cursive", Body = "Inter") so the two are visually and computationally distinguishable.

1. **Baseline - global Heading/Body only, no per-level override**
   - Add a block with a title control set to "Default" (e.g. Magazine Blocks Featured Posts / Banner Posts / Post List; or the native Post Title field).
   - Expected: title renders in the Heading font in the block editor, front-end, and Customizer preview alike.
   - Verified: computed `font-family` matches, and the actual font file is present in `document.fonts` with `status: "loaded"` (not just the CSS declaration) — confirmed on Featured Posts (regular + highlighted post title) and Banner Posts.

2. **Per-level H1-H6 override differs from the global Heading font**
   - Set `colormag_h3_typography` to a font different from the global Heading font (e.g. "Pacifico" vs. global "Cedarville Cursive").
   - Expected: elements rendered as `<h3>` (e.g. Magazine Blocks' Featured/Banner Posts titles, which default to `h3`) show the H3-specific font; other heading levels (h1, h2, etc. without an override) keep the general Heading font.
   - Verified: both the CSS declaration and the actual loaded font file (`document.fonts` entry, `status: "loaded"`) for the override font; confirmed visually via screenshot that the H3 titles render in a visibly different script from the H1 page title / H2 heading.

3. **Reverting the per-level override (regression check)**
   - Reset `colormag_h3_typography` back to "Default".
   - Expected: H3 elements fall back to the general Heading font again, with no leftover styling from the previous override.
   - Verified: re-checked computed style after reverting - correctly back to the general Heading font.

4. **"Load Google Fonts locally" Customizer option**
   - Reasoned through code (not re-verified live in-browser after the latest commit): when `colormag_load_google_fonts_locally` is enabled and no custom font is configured, `get_google_fonts_url_by_ids()` returns `false`, and the "Open Sans" fallback is correctly *not* loaded (matching pre-existing front-end behavior) — this parity was preserved deliberately in the `elseif ( ! $host_fonts_locally )` fallback branch.

5. **Front-end and Customizer live preview (no-regression check)**
   - Confirmed both remain unaffected and correct after all the changes above - they never had this bug in the first place, and nothing in this PR touches their code paths except via the shared default-value getters, which were diffed byte-for-byte against the original to confirm zero value changes.

6. **Full-file diff safety check**
   - Every extracted default-value array and the typography ID list were diffed programmatically against the pre-change file (not just visually reviewed) and confirmed byte-identical.
   - Every function in both changed files that was *not* intended to change was also diffed against the original and confirmed untouched, covering both files end-to-end.

## Not yet tested
- Combinations with Heading + Body + multiple H-levels all customized simultaneously.
- RTL and the dark color-skin variant.
- Other Magazine Blocks blocks beyond Featured Posts / Banner Posts / Post List (Slider, Tab Post, Grid Module, etc. use the same underlying markup/CSS pattern, so should behave identically, but weren't individually clicked through).
- Manual QA on staging across real sites with varied combinations of these settings.