### PR TITLE
CMAG-686 Fix - Header builder button typography missing, add search icon size option

### DIFF
--- a/inc/base/class-colormag-dynamic-builder-css.php
+++ b/inc/base/class-colormag-dynamic-builder-css.php
@@ -294,6 +294,53 @@ class ColorMag_Dynamic_Builder_CSS {
 		);
 		$parse_builder_css                       .= colormag_parse_css( '#ffffff', $header_button_background_hover_color, $header_button_background_hover_color_css );
 
+		// Header button typography.
+		$header_button_typography_default = array(
+			'font-family'    => 'default',
+			'font-weight'    => 'regular',
+			'subsets'        => array( 'latin' ),
+			'font-size'      => array(
+				'desktop' => array(
+					'size' => '',
+					'unit' => 'px',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => 'px',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => 'px',
+				),
+			),
+			'line-height'    => array(
+				'desktop' => array(
+					'size' => '',
+					'unit' => '-',
+				),
+				'tablet'  => array(
+					'size' => '',
+					'unit' => '-',
+				),
+				'mobile'  => array(
+					'size' => '',
+					'unit' => '-',
+				),
+			),
+			'font-style'     => 'normal',
+			'text-transform' => 'none',
+		);
+		$header_button_typography         = get_theme_mod( 'colormag_header_button_typography', $header_button_typography_default );
+		$parse_builder_css               .= colormag_parse_typography_css(
+			$header_button_typography_default,
+			$header_button_typography,
+			'.cm-header-builder .cm-header-buttons .cm-header-button .cm-button',
+			array(
+				'tablet' => 768,
+				'mobile' => 600,
+			)
+		);
+
 		// Header button padding.
 		$header_button_padding_default = array(
 			'top'    => '5',
@@ -967,6 +1014,36 @@ class ColorMag_Dynamic_Builder_CSS {
 			),
 		);
 		$parse_builder_css           .= colormag_parse_css( '', $header_search_icon_color, $header_search_icon_color_css );
+
+		// Header search icon size.
+		$header_search_icon_size_default = array(
+			'size' => '',
+			'unit' => 'px',
+		);
+		$header_search_icon_size         = get_theme_mod( 'colormag_header_search_icon_size', $header_search_icon_size_default );
+		$parse_builder_css               .= colormag_parse_slider_css(
+			$header_search_icon_size_default,
+			$header_search_icon_size,
+			'.cm-header-builder .cm-top-search .search-top::before, .cm-header-builder .search-wrap .search-icon::before',
+			'font-size'
+		);
+		$parse_builder_css               .= colormag_parse_slider_css(
+			$header_search_icon_size_default,
+			$header_search_icon_size,
+			'.cm-search-icon-in-input-right .search-icon-input-right svg',
+			'width'
+		);
+		$parse_builder_css               .= colormag_parse_slider_css(
+			$header_search_icon_size_default,
+			$header_search_icon_size,
+			'.cm-search-icon-in-input-right .search-icon-input-right svg',
+			'height'
+		);
+
+		// Let the fixed 48px `.fa.search-top` box grow with a custom icon size instead of clipping it.
+		if ( ! empty( $header_search_icon_size['size'] ) ) {
+			$parse_builder_css .= '.cm-header-builder .fa.search-top{width:auto;height:auto;}';
+		}
 
 		// Header search button background color.
 		$header_search_button_bg     = get_theme_mod( 'colormag_header_search_button_background', '' );

--- a/inc/customizer/assets/js/cm-customize-preview.js
+++ b/inc/customizer/assets/js/cm-customize-preview.js
@@ -1011,6 +1011,14 @@
 					);
 					break;
 
+				case 'colormag_header_button_typography':
+					css = colormagGenerateTypographyCSS(
+						id,
+						'.cm-header-builder .cm-header-buttons .cm-header-button .cm-button',
+						value,
+					);
+					break;
+
 				case 'colormag_header_button_padding':
 					css = colormagGenerateDimensionCSS(
 						'.cm-header-builder .cm-header-buttons .cm-header-button .cm-button',
@@ -1277,6 +1285,28 @@
 						'color',
 						value,
 					);
+					break;
+
+				case 'colormag_header_search_icon_size':
+					css = colormagGenerateSliderCSS(
+						'.cm-header-builder .cm-top-search .search-top::before, .cm-header-builder .search-wrap .search-icon::before',
+						'font-size',
+						value,
+					);
+					css += colormagGenerateSliderCSS(
+						'.cm-search-icon-in-input-right .search-icon-input-right svg',
+						'width',
+						value,
+					);
+					css += colormagGenerateSliderCSS(
+						'.cm-search-icon-in-input-right .search-icon-input-right svg',
+						'height',
+						value,
+					);
+					// Let the fixed 48px `.fa.search-top` box grow with a custom icon size instead of clipping it.
+					if (value.size) {
+						css += '.cm-header-builder .fa.search-top{width:auto;height:auto;}';
+					}
 					break;
 
 				case 'colormag_header_search_icon_hover_color':

--- a/inc/customizer/options/header-builder/header-button.php
+++ b/inc/customizer/options/header-builder/header-button.php
@@ -71,6 +71,47 @@ $options = array(
 						),
 					),
 				),
+				'colormag_header_button_typography'    => array(
+					'default'   => array(
+						'font-family'    => 'default',
+						'font-weight'    => 'regular',
+						'subsets'        => array( 'latin' ),
+						'font-size'      => array(
+							'desktop' => array(
+								'size' => '',
+								'unit' => 'px',
+							),
+							'tablet'  => array(
+								'size' => '',
+								'unit' => 'px',
+							),
+							'mobile'  => array(
+								'size' => '',
+								'unit' => 'px',
+							),
+						),
+						'line-height'    => array(
+							'desktop' => array(
+								'size' => '',
+								'unit' => '-',
+							),
+							'tablet'  => array(
+								'size' => '',
+								'unit' => '-',
+							),
+							'mobile'  => array(
+								'size' => '',
+								'unit' => '-',
+							),
+						),
+						'font-style'     => 'normal',
+						'text-transform' => 'none',
+					),
+					'type'      => 'customind-typography',
+					'transport' => 'postMessage',
+					'title'     => esc_html__( 'Typography', 'colormag' ),
+					'section'   => 'colormag_header_builder_button_1',
+				),
 				'colormag_header_button_padding'       => array(
 					'default'     => array(
 						'top'    => '5',

--- a/inc/customizer/options/header-builder/search.php
+++ b/inc/customizer/options/header-builder/search.php
@@ -115,6 +115,23 @@ $options = array(
 					'transport' => 'postMessage',
 					'section'   => 'colormag_header_builder_search',
 				),
+				'colormag_header_search_icon_size'  => array(
+					'default'     => array(
+						'size'  => '',
+						'units' => 'px',
+					),
+					'type'        => 'customind-slider',
+					'title'       => esc_html__( 'Icon Size', 'colormag' ),
+					'transport'   => 'postMessage',
+					'section'     => 'colormag_header_builder_search',
+					'units'       => array( 'px' ),
+					'defaultUnit' => 'px',
+					'input_attrs' => array(
+						'min'  => 10,
+						'max'  => 60,
+						'step' => 1,
+					),
+				),
 				'colormag_header_search_button_background_group' => array(
 					'type'         => 'customind-color-group',
 					'title'        => esc_html__( 'Background', 'colormag' ),


### PR DESCRIPTION
## Summary
- Add a Typography control (font-family, weight, size, line-height, style, text-transform) to the header-builder Button element, matching the pattern already used by the Date element's `colormag_date_typography` control.
- Add an Icon Size control for the Search element, applied to both search icon rendering modes: the FontAwesome glyph (`::before`) used by "Normal Search"/"Search Box" types, and the inline SVG used by "Icon Inside Search".
- Fix a related layout bug found during testing: `.fa.search-top`'s background box was hardcoded to a fixed 48x48px, so increasing the new Icon Size control would overflow the icon past its own background box. The box now scales with a custom icon size instead of clipping it.

## Jira
https://themegrill.atlassian.net/browse/CMAG-686

## Test plan
- [x] Verified Button Typography control renders in Customizer, live-previews correctly, and persists to the frontend after Publish
- [x] Verified Search Icon Size control renders, live-previews correctly for both "Normal Search" and "Icon Inside Search" types, and persists to the frontend
- [x] Verified the search icon background box scales proportionately with custom icon sizes (tested 15px and 55px) with no clipping/overflow, both in the live preview and on the published frontend