### PR TITLE
Fix: Customizer typography fonts not reflecting in block editor

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -582,6 +582,36 @@ add_filter(
 			],
 		];
 
+		// Also surface whatever font families are currently configured in the
+		// Customizer, so the Global Styles font list always matches what the
+		// user actually picked there instead of only offering the curated
+		// defaults above.
+		if ( class_exists( 'ColorMag_Enqueue_Scripts' ) ) {
+			$configured_slugs = wp_list_pluck( $google_fonts, 'slug' );
+
+			foreach ( ColorMag_Enqueue_Scripts::get_instance()->get_typography_ids() as $typography_id ) {
+				$value = get_theme_mod( $typography_id );
+
+				if ( empty( $value['font-family'] ) || 'default' === strtolower( $value['font-family'] ) ) {
+					continue;
+				}
+
+				$family = $value['font-family'];
+				$slug   = sanitize_title( $family );
+
+				if ( in_array( $slug, $configured_slugs, true ) ) {
+					continue;
+				}
+
+				$configured_slugs[] = $slug;
+				$google_fonts[]     = [
+					'name'       => $family,
+					'slug'       => $slug,
+					'fontFamily' => $family . ', sans-serif',
+				];
+			}
+		}
+
 		$existing = $json->get_data()['settings']['typography']['fontFamilies']['theme'] ?? [];
 		$json->update_with(
 			[
@@ -601,18 +631,10 @@ add_filter(
 	10
 );
 
-// Enqueue Google Fonts in the block editor (all weights and variable fonts)
-add_action(
-	'enqueue_block_editor_assets',
-	function () {
-		wp_enqueue_style(
-			'colormag-google-fonts',
-			'https://fonts.googleapis.com/css2?family=DM+Sans:wght@100..900&family=Public+Sans:wght@100..900&family=Roboto:wght@100..900&display=swap',
-			[],
-			null
-		);
-	}
-);
+// The actual Google Fonts stylesheet for the block editor is enqueued by
+// ColorMag_Enqueue_Scripts::colormag_block_editor_styles() (hooked to
+// `enqueue_block_assets`), which builds the font URL from the Customizer's
+// configured typography — see inc/core/class-colormag-enqueue-scripts.php.
 
 function colormag_typography_should_migrate() {
 	// Default values for comparison

--- a/inc/base/class-colormag-dynamic-css.php
+++ b/inc/base/class-colormag-dynamic-css.php
@@ -1365,10 +1365,14 @@ class ColorMag_Dynamic_CSS {
 		$base_typography_default = self::get_base_typography_default();
 		$base_typography         = get_theme_mod( 'colormag_base_typography', $base_typography_default );
 
+		// `.editor-styles-wrapper > *` also needs to be targeted directly (not just
+		// relied on via inheritance): style-editor-block.css hardcodes a font-family
+		// on every direct child to normalize block defaults, which otherwise wins
+		// over an inherited value from `.editor-styles-wrapper` alone.
 		$parse_css .= colormag_parse_typography_css(
 			$base_typography_default,
 			$base_typography,
-			'.editor-styles-wrapper'
+			'.editor-styles-wrapper, .editor-styles-wrapper > *'
 		);
 
 		// Headings typography.

--- a/inc/core/class-colormag-enqueue-scripts.php
+++ b/inc/core/class-colormag-enqueue-scripts.php
@@ -210,7 +210,7 @@ if ( ! class_exists( 'ColorMag_Enqueue_Scripts' ) ) {
 		 *
 		 * @return array
 		 */
-		private function get_typography_ids() {
+		public function get_typography_ids() {
 			return apply_filters(
 				'colormag_enqueue_scripts_typography_ids',
 				array(


### PR DESCRIPTION
## Summary

Customizer typography fonts weren't showing up correctly in the block editor, even though the previous fix (93130333) for this was in place. Two separate issues were causing it:

- **Hardcoded font list overriding the dynamic mechanism** — `functions.php` had a static block that always enqueued 4 fixed Google Fonts (DM Sans, Public Sans, Roboto, Segoe UI) into the block editor and hardcoded the same 4 into the Global Styles font palette, regardless of what was actually selected in the Customizer. Removed the redundant enqueue (the correct dynamic one already exists in `ColorMag_Enqueue_Scripts::colormag_block_editor_styles()`), and made the Global Styles font list also include whatever fonts are currently configured in the Customizer.
- **Paragraph/body text specifically not picking up the font** — `style-editor-block.css` sets an explicit `font-family` on every direct child of `.editor-styles-wrapper` (a hardcoded "Open Sans" reset). Since the Customizer's base typography CSS only targeted `.editor-styles-wrapper` itself and relied on inheritance, that explicit child-level rule always won. Headings were unaffected because their CSS already targets `h1`-`h6` directly. Fixed by having the base typography CSS also target `.editor-styles-wrapper > *` directly, the same way headings already do.

## Changes

- `functions.php` — removed the hardcoded `enqueue_block_editor_assets` Google Fonts call; Global Styles font list filter now also pulls in the Customizer's configured font families.
- `inc/core/class-colormag-enqueue-scripts.php` — made `get_typography_ids()` public so it can be reused from `functions.php`.
- `inc/base/class-colormag-dynamic-css.php` — base typography editor CSS now also targets `.editor-styles-wrapper > *` directly instead of relying on inheritance alone.

## Test plan

- [x] `php -l` on all changed files
- [x] `pnpm run build` and `gulp build` complete cleanly, release zip regenerated
- [x] Manually verified in the block editor: headings and paragraph/body text both now render with the font configured via Customizer typography presets
- [x] Verified front-end rendering is unaffected (already worked correctly)

---
_Note: a related but distinct block-editor button/color styling fix was split out into its own PR, #286, for clarity._