### PR TITLE
Fix: remove fixed, non-configurable top margin on .cm-entry-summary

### DIFF
--- a/assets/sass/components/entry/_summary.scss
+++ b/assets/sass/components/entry/_summary.scss
@@ -1,5 +1,4 @@
 .cm-entry-summary {
-	margin-top: length( 'l-6' );
 
 	p {
 		margin-bottom: length( 'l-12', em );

--- a/style.css
+++ b/style.css
@@ -3035,9 +3035,6 @@ Styles for separating single posts loaded from ajax call.
 	font-size: 1.2rem;
 }
 
-.cm-entry-summary {
-	margin-top: 12px;
-}
 .cm-entry-summary p {
 	margin-bottom: 1.5em;
 	font-size: 1.4rem;


### PR DESCRIPTION
## Summary

`.cm-entry-summary` (the wrapper around post content on singular pages, and excerpts on archive/blog listings) carried a hardcoded `margin-top: 12px` with no way to adjust or remove it — not tied to any Customizer setting, not intentionally designed. It was pulled in incidentally by a 2023 bulk "theme revamp" file transfer, not added as a deliberate spacing decision.

Users who wanted a different (or zero) gap above the content/excerpt had no supported way to do it short of writing custom CSS — a bad experience for something that isn't even an intentional design choice.

## Changes

- `assets/sass/components/entry/_summary.scss` — removed the fixed `margin-top` declaration on `.cm-entry-summary`.
- `style.css` — recompiled to drop the corresponding static rule.

Not adding a new Customizer control for this: it would be one more setting for a value nobody actually chose, when users already have Additional CSS / block-level spacing to get any gap they want. Removing the unremovable default is the right fix, not exposing it.

## Note

`style-rtl.css` was intentionally left out of this PR — regenerating it revealed pre-existing drift from `style.css` unrelated to this change (a stale version string and a couple of unrelated selectors), which should be reconciled separately rather than folded into this fix.

## Test plan

- [x] `gulp build` recompiles cleanly, `.cm-entry-summary { margin-top: 12px; }` no longer present in `style.css`
- [ ] Visual check across single-post, archive/blog-card, and widget contexts where `.cm-entry-summary` renders, to confirm no unwanted layout regression from the removed margin