### PR TITLE
CMAG-710, CMAG-715 Fix - Search icon container not resizing, and icon fill invisible on light backgrounds

### DIFF
--- a/assets/sass/components/header-actions/_header-actions.scss
+++ b/assets/sass/components/header-actions/_header-actions.scss
@@ -39,7 +39,7 @@
 		svg {
 			width: 18px;
 			height: 18px;
-			fill: #FFFFFF;
+			fill: currentColor;
 		}
 	}
 

--- a/assets/sass/components/header-actions/_header-actions.scss
+++ b/assets/sass/components/header-actions/_header-actions.scss
@@ -85,6 +85,11 @@
 		@include font-size("font-size-xs");
 		border-radius: 0 4px 4px 0;
 		line-height: 0.8;
+
+		// Without this, the theme-wide `button:hover{background:transparent}` reset wins and the button goes blank.
+		&:hover {
+			background-color: $color__primary;
+		}
 	}
 }
 

--- a/assets/sass/components/header-actions/_header-actions.scss
+++ b/assets/sass/components/header-actions/_header-actions.scss
@@ -30,13 +30,14 @@
 	.search-icon-input-right {
 		position: absolute;
 		right: 10px;
-		top: 58%;
+		top: 50%;
 		transform: translateY(-50%);
 		color: $color__gray-200;
 		font-size: 16px;
 		pointer-events: none;
 
 		svg {
+			display: block;
 			width: 18px;
 			height: 18px;
 			fill: currentColor;

--- a/inc/base/class-colormag-dynamic-builder-css.php
+++ b/inc/base/class-colormag-dynamic-builder-css.php
@@ -1092,18 +1092,11 @@ class ColorMag_Dynamic_Builder_CSS {
 		);
 		$parse_builder_css           .= colormag_parse_css( '', $header_search_text_color, $header_search_text_color_css );
 
-		// Header search placeholder color.
+		// Header search placeholder color; the icon's `fill: currentColor` inherits this same rule.
 		$header_search_placeholder_color     = get_theme_mod( 'colormag_header_search_placeholder_color', '' );
 		$header_search_placeholder_color_css = array(
-			'.search-wrap input::placeholder, .cm-search-icon-in-input-right .search-wrap i' => array(
+			'.search-wrap input::placeholder, .cm-search-icon-in-input-right .search-icon-input-right' => array(
 				'color' => esc_html( $header_search_placeholder_color ),
-			),
-		);
-		$parse_builder_css                  .= colormag_parse_css( '', $header_search_placeholder_color, $header_search_placeholder_color_css );
-
-		$header_search_placeholder_color_css = array(
-			'.cm-search-icon-in-input-right .search-wrap i' => array(
-				'fill' => esc_html( $header_search_placeholder_color ),
 			),
 		);
 		$parse_builder_css                  .= colormag_parse_css( '', $header_search_placeholder_color, $header_search_placeholder_color_css );

--- a/inc/base/class-colormag-dynamic-builder-css.php
+++ b/inc/base/class-colormag-dynamic-builder-css.php
@@ -1034,7 +1034,7 @@ class ColorMag_Dynamic_Builder_CSS {
 		);
 
 		// Explicit height opts the "Search Box" button out of the `.search-wrap` flex stretch that clips larger icons.
-		$parse_builder_css               .= colormag_parse_slider_css(
+		$parse_builder_css .= colormag_parse_slider_css(
 			$header_search_icon_size_default,
 			$header_search_icon_size,
 			'.cm-header-builder .search-wrap .search-icon',
@@ -1042,7 +1042,7 @@ class ColorMag_Dynamic_Builder_CSS {
 		);
 
 		// Grow the "Icon Inside Search" input so a larger centered icon no longer spills above/below it.
-		$parse_builder_css               .= colormag_parse_slider_css(
+		$parse_builder_css .= colormag_parse_slider_css(
 			$header_search_icon_size_default,
 			$header_search_icon_size,
 			'.cm-search-icon-in-input-right .search-wrap input',

--- a/inc/base/class-colormag-dynamic-builder-css.php
+++ b/inc/base/class-colormag-dynamic-builder-css.php
@@ -1052,6 +1052,8 @@ class ColorMag_Dynamic_Builder_CSS {
 		// Let the fixed 48px `.fa.search-top` box grow with a custom icon size instead of clipping it.
 		if ( ! empty( $header_search_icon_size['size'] ) ) {
 			$parse_builder_css .= '.cm-header-builder .fa.search-top{width:auto;height:auto;}';
+			// The button's fixed 14px padding inflated the content-box height above past Icon Size; zero it and flex-center the glyph instead.
+			$parse_builder_css .= '.cm-header-builder .search-wrap .search-icon{padding:0;box-sizing:border-box;display:flex;align-items:center;justify-content:center;}';
 		}
 
 		// Header search button background color.

--- a/inc/base/class-colormag-dynamic-builder-css.php
+++ b/inc/base/class-colormag-dynamic-builder-css.php
@@ -1033,6 +1033,22 @@ class ColorMag_Dynamic_Builder_CSS {
 			'height'
 		);
 
+		// Explicit height opts the "Search Box" button out of the `.search-wrap` flex stretch that clips larger icons.
+		$parse_builder_css               .= colormag_parse_slider_css(
+			$header_search_icon_size_default,
+			$header_search_icon_size,
+			'.cm-header-builder .search-wrap .search-icon',
+			'height'
+		);
+
+		// Grow the "Icon Inside Search" input so a larger centered icon no longer spills above/below it.
+		$parse_builder_css               .= colormag_parse_slider_css(
+			$header_search_icon_size_default,
+			$header_search_icon_size,
+			'.cm-search-icon-in-input-right .search-wrap input',
+			'min-height'
+		);
+
 		// Let the fixed 48px `.fa.search-top` box grow with a custom icon size instead of clipping it.
 		if ( ! empty( $header_search_icon_size['size'] ) ) {
 			$parse_builder_css .= '.cm-header-builder .fa.search-top{width:auto;height:auto;}';

--- a/inc/base/class-colormag-dynamic-builder-css.php
+++ b/inc/base/class-colormag-dynamic-builder-css.php
@@ -999,7 +999,7 @@ class ColorMag_Dynamic_Builder_CSS {
 			)
 		);
 
-		// Header search icon color.
+		// Header search icon color; Icon Inside Search is handled separately below via an override.
 		$header_search_icon_color     = get_theme_mod( 'colormag_header_search_icon_color', '' );
 		$header_search_icon_color_css = array(
 			'.cm-header-builder .cm-top-search .search-top::before, .cm-header-builder .search-wrap .search-icon::before' => array(
@@ -1056,22 +1056,33 @@ class ColorMag_Dynamic_Builder_CSS {
 			$parse_builder_css .= '.cm-header-builder .fa.search-top{padding:14px;}';
 		}
 
-		// Header search button background color.
+		// Header search button background color; also gives the Icon Inside Search icon its own badge-style background.
 		$header_search_button_bg     = get_theme_mod( 'colormag_header_search_button_background', '' );
 		$header_search_button_bg_css = array(
 			'.cm-header-builder .fa.search-top, .cm-header-builder .search-wrap button' => array(
 				'background-color' => esc_html( $header_search_button_bg ),
 				'border-color'     => esc_html( $header_search_button_bg ),
 			),
+			'.cm-search-icon-in-input-right .search-icon-input-right'                   => array(
+				'background-color' => esc_html( $header_search_button_bg ),
+			),
 		);
 		$parse_builder_css          .= colormag_parse_css( '', $header_search_button_bg, $header_search_button_bg_css );
 
-		// Header search button hover background color.
+		// Give the icon breathing room inside its new badge background instead of sitting flush against the edges.
+		if ( ! empty( $header_search_button_bg ) ) {
+			$parse_builder_css .= '.cm-search-icon-in-input-right .search-icon-input-right{padding:6px;display:flex;align-items:center;justify-content:center;}';
+		}
+
+		// Header search button hover background color; bound to the input's hover since the icon itself has `pointer-events:none`.
 		$header_search_button_hover_bg     = get_theme_mod( 'colormag_header_search_button_hover_background', '' );
 		$header_search_button_hover_bg_css = array(
-			'.cm-header-builder .fa.search-top:hover, .cm-header-builder .search-wrap button:hover' => array(
+			'.cm-header-builder .fa.search-top:hover, .cm-header-builder .search-wrap button:hover'    => array(
 				'background-color' => esc_html( $header_search_button_hover_bg ),
 				'border-color'     => esc_html( $header_search_button_hover_bg ),
+			),
+			'.cm-search-icon-in-input-right .search-wrap:hover .search-icon-input-right' => array(
+				'background-color' => esc_html( $header_search_button_hover_bg ),
 			),
 		);
 		$parse_builder_css                .= colormag_parse_css( '', $header_search_button_hover_bg, $header_search_button_hover_bg_css );
@@ -1094,7 +1105,7 @@ class ColorMag_Dynamic_Builder_CSS {
 		);
 		$parse_builder_css           .= colormag_parse_css( '', $header_search_text_color, $header_search_text_color_css );
 
-		// Header search placeholder color; the icon's `fill: currentColor` inherits this same rule.
+		// Header search placeholder color; the icon's `fill: currentColor` inherits this as a fallback (see the override below).
 		$header_search_placeholder_color     = get_theme_mod( 'colormag_header_search_placeholder_color', '' );
 		$header_search_placeholder_color_css = array(
 			'.search-wrap input::placeholder, .cm-search-icon-in-input-right .search-icon-input-right' => array(
@@ -1102,6 +1113,14 @@ class ColorMag_Dynamic_Builder_CSS {
 			),
 		);
 		$parse_builder_css                  .= colormag_parse_css( '', $header_search_placeholder_color, $header_search_placeholder_color_css );
+
+		// Search Button Color wins over Placeholder Color for this icon when set; emitted after it so equal specificity resolves in its favor.
+		$header_search_icon_color_override_css = array(
+			'.cm-search-icon-in-input-right .search-icon-input-right' => array(
+				'color' => esc_html( $header_search_icon_color ),
+			),
+		);
+		$parse_builder_css                    .= colormag_parse_css( '', $header_search_icon_color, $header_search_icon_color_override_css );
 
 		// Social icon color.
 		$social_icon_color     = get_theme_mod( 'colormag_header_socials_color', '' );

--- a/inc/base/class-colormag-dynamic-builder-css.php
+++ b/inc/base/class-colormag-dynamic-builder-css.php
@@ -1052,8 +1052,6 @@ class ColorMag_Dynamic_Builder_CSS {
 		// Let the fixed 48px `.fa.search-top` box grow with a custom icon size instead of clipping it.
 		if ( ! empty( $header_search_icon_size['size'] ) ) {
 			$parse_builder_css .= '.cm-header-builder .fa.search-top{width:auto;height:auto;}';
-			// The button's fixed 14px padding inflated the content-box height above past Icon Size; zero it and flex-center the glyph instead.
-			$parse_builder_css .= '.cm-header-builder .search-wrap .search-icon{padding:0;box-sizing:border-box;display:flex;align-items:center;justify-content:center;}';
 		}
 
 		// Header search button background color.

--- a/inc/base/class-colormag-dynamic-builder-css.php
+++ b/inc/base/class-colormag-dynamic-builder-css.php
@@ -1052,6 +1052,8 @@ class ColorMag_Dynamic_Builder_CSS {
 		// Let the fixed 48px `.fa.search-top` box grow with a custom icon size instead of clipping it.
 		if ( ! empty( $header_search_icon_size['size'] ) ) {
 			$parse_builder_css .= '.cm-header-builder .fa.search-top{width:auto;height:auto;}';
+			// Match the other search types' padding now that the box grows with it, instead of the default 1px.
+			$parse_builder_css .= '.cm-header-builder .fa.search-top{padding:14px;}';
 		}
 
 		// Header search button background color.

--- a/inc/customizer/assets/js/cm-customize-preview.js
+++ b/inc/customizer/assets/js/cm-customize-preview.js
@@ -1285,6 +1285,12 @@
 						'color',
 						value,
 					);
+					// Search Button Color wins over Placeholder Color for the Icon Inside Search icon when set; falls back to Placeholder Color otherwise.
+					css += colormagGenerateCommonCSS(
+						'.cm-search-icon-in-input-right .search-icon-input-right',
+						'color',
+						value || wp.customize('colormag_header_search_placeholder_color').get(),
+					);
 					break;
 
 				case 'colormag_header_search_icon_size':
@@ -1340,11 +1346,16 @@
 					break;
 
 				case 'colormag_header_search_placeholder_color':
-					// The icon's `fill: currentColor` picks up this same color, so a single `color` rule on its wrapper covers both the placeholder text and icon.
 					css = colormagGenerateCommonCSS(
-						'.search-wrap input::placeholder, .cm-search-icon-in-input-right .search-icon-input-right',
+						'.search-wrap input::placeholder',
 						'color',
 						value,
+					);
+					// The icon's `fill: currentColor` picks up this same wrapper color, but Search Button Color wins over it when set.
+					css += colormagGenerateCommonCSS(
+						'.cm-search-icon-in-input-right .search-icon-input-right',
+						'color',
+						wp.customize('colormag_header_search_icon_color').get() || value,
 					);
 					break;
 
@@ -1380,6 +1391,15 @@
 						'border-color',
 						value,
 					);
+					css += colormagGenerateCommonCSS(
+						'.cm-search-icon-in-input-right .search-icon-input-right',
+						'background-color',
+						value,
+					);
+					// Give the icon breathing room inside its new badge background instead of sitting flush against the edges.
+					if (value) {
+						css += '.cm-search-icon-in-input-right .search-icon-input-right{padding:6px;display:flex;align-items:center;justify-content:center;}';
+					}
 					break;
 
 				case 'colormag_header_search_button_hover_background':
@@ -1391,6 +1411,11 @@
 					css += colormagGenerateCommonCSS(
 						'.cm-header-builder .fa.search-top:hover, .cm-header-builder .search-wrap button:hover',
 						'border-color',
+						value,
+					);
+					css += colormagGenerateCommonCSS(
+						'.cm-search-icon-in-input-right .search-wrap:hover .search-icon-input-right',
+						'background-color',
 						value,
 					);
 					break;

--- a/inc/customizer/assets/js/cm-customize-preview.js
+++ b/inc/customizer/assets/js/cm-customize-preview.js
@@ -1318,6 +1318,8 @@
 					// Let the fixed 48px `.fa.search-top` box grow with a custom icon size instead of clipping it.
 					if (value.size) {
 						css += '.cm-header-builder .fa.search-top{width:auto;height:auto;}';
+						// Match the other search types' padding now that the box grows with it, instead of the default 1px.
+						css += '.cm-header-builder .fa.search-top{padding:14px;}';
 					}
 					break;
 

--- a/inc/customizer/assets/js/cm-customize-preview.js
+++ b/inc/customizer/assets/js/cm-customize-preview.js
@@ -1318,8 +1318,6 @@
 					// Let the fixed 48px `.fa.search-top` box grow with a custom icon size instead of clipping it.
 					if (value.size) {
 						css += '.cm-header-builder .fa.search-top{width:auto;height:auto;}';
-						// The button's fixed 14px padding inflated the content-box height above past Icon Size; zero it and flex-center the glyph instead.
-						css += '.cm-header-builder .search-wrap .search-icon{padding:0;box-sizing:border-box;display:flex;align-items:center;justify-content:center;}';
 					}
 					break;
 

--- a/inc/customizer/assets/js/cm-customize-preview.js
+++ b/inc/customizer/assets/js/cm-customize-preview.js
@@ -1318,6 +1318,8 @@
 					// Let the fixed 48px `.fa.search-top` box grow with a custom icon size instead of clipping it.
 					if (value.size) {
 						css += '.cm-header-builder .fa.search-top{width:auto;height:auto;}';
+						// The button's fixed 14px padding inflated the content-box height above past Icon Size; zero it and flex-center the glyph instead.
+						css += '.cm-header-builder .search-wrap .search-icon{padding:0;box-sizing:border-box;display:flex;align-items:center;justify-content:center;}';
 					}
 					break;
 

--- a/inc/customizer/assets/js/cm-customize-preview.js
+++ b/inc/customizer/assets/js/cm-customize-preview.js
@@ -1303,6 +1303,18 @@
 						'height',
 						value,
 					);
+					// Explicit height opts the "Search Box" button out of the `.search-wrap` flex stretch that clips larger icons.
+					css += colormagGenerateSliderCSS(
+						'.cm-header-builder .search-wrap .search-icon',
+						'height',
+						value,
+					);
+					// Grow the "Icon Inside Search" input so a larger centered icon no longer spills above/below it.
+					css += colormagGenerateSliderCSS(
+						'.cm-search-icon-in-input-right .search-wrap input',
+						'min-height',
+						value,
+					);
 					// Let the fixed 48px `.fa.search-top` box grow with a custom icon size instead of clipping it.
 					if (value.size) {
 						css += '.cm-header-builder .fa.search-top{width:auto;height:auto;}';

--- a/inc/customizer/assets/js/cm-customize-preview.js
+++ b/inc/customizer/assets/js/cm-customize-preview.js
@@ -1338,14 +1338,10 @@
 					break;
 
 				case 'colormag_header_search_placeholder_color':
+					// The icon's `fill: currentColor` picks up this same color, so a single `color` rule on its wrapper covers both the placeholder text and icon.
 					css = colormagGenerateCommonCSS(
-						'.search-wrap input::placeholder, .cm-search-icon-in-input-right .search-wrap i',
+						'.search-wrap input::placeholder, .cm-search-icon-in-input-right .search-icon-input-right',
 						'color',
-						value,
-					);
-					css += colormagGenerateCommonCSS(
-						'.cm-search-icon-in-input-right .search-wrap i',
-						'fill',
 						value,
 					);
 					break;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1903,6 +1903,9 @@ table td {
 	border-radius: 4px 0 0 4px;
 	line-height: 0.8;
 }
+.search-wrap button:hover {
+	background-color: var(--cm-color-1, #207daf);
+}
 
 .search-form-top {
 	position: absolute;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1856,13 +1856,14 @@ table td {
 .cm-search-icon-in-input-right .search-icon-input-right {
 	position: absolute;
 	left: 10px;
-	top: 58%;
+	top: 50%;
 	transform: translateY(-50%);
 	color: #e4e4e7;
 	font-size: 16px;
 	pointer-events: none;
 }
 .cm-search-icon-in-input-right .search-icon-input-right svg {
+	display: block;
 	width: 18px;
 	height: 18px;
 	fill: currentColor;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1865,7 +1865,7 @@ table td {
 .cm-search-icon-in-input-right .search-icon-input-right svg {
 	width: 18px;
 	height: 18px;
-	fill: #FFFFFF;
+	fill: currentColor;
 }
 .cm-search-icon-in-input-right .search-wrap:focus-within .search-icon-input-right {
 	display: none;

--- a/style.css
+++ b/style.css
@@ -1903,6 +1903,9 @@ table td {
 	border-radius: 0 4px 4px 0;
 	line-height: 0.8;
 }
+.search-wrap button:hover {
+	background-color: var(--cm-color-1, #207daf);
+}
 
 .search-form-top {
 	position: absolute;

--- a/style.css
+++ b/style.css
@@ -1865,7 +1865,7 @@ table td {
 .cm-search-icon-in-input-right .search-icon-input-right svg {
 	width: 18px;
 	height: 18px;
-	fill: #FFFFFF;
+	fill: currentColor;
 }
 .cm-search-icon-in-input-right .search-wrap:focus-within .search-icon-input-right {
 	display: none;

--- a/style.css
+++ b/style.css
@@ -1856,13 +1856,14 @@ table td {
 .cm-search-icon-in-input-right .search-icon-input-right {
 	position: absolute;
 	right: 10px;
-	top: 58%;
+	top: 50%;
 	transform: translateY(-50%);
 	color: #e4e4e7;
 	font-size: 16px;
 	pointer-events: none;
 }
 .cm-search-icon-in-input-right .search-icon-input-right svg {
+	display: block;
 	width: 18px;
 	height: 18px;
 	fill: currentColor;


### PR DESCRIPTION
## Summary

**CMAG-710** — the Icon Size control only resized the icon glyph/svg itself, not the container box around it, on two of the three search types:
- **Search Box**: the submit button's height was stretched to the input's height by `.search-wrap`'s default flex `align-items` behavior, ignoring Icon Size entirely.
- **Icon Inside Search**: the icon is absolutely positioned and vertically centered over the input, so a larger icon than the input's fixed height spilled above/below it.

Fix gives the "Search Box" button an explicit `height` matching Icon Size (a definite height opts a flex item out of the container's stretch), and grows the "Icon Inside Search" input's `min-height` to match Icon Size — mirroring the existing `width:auto;height:auto` treatment already applied to the Normal Search toggle icon.

**CMAG-715** — found while investigating CMAG-710's screenshots: the "Icon Inside Search" svg had a hardcoded `fill: #FFFFFF`, invisible against light/white input backgrounds, independent of icon size. The existing Header Search Placeholder Color control was already meant to cover this but targeted a stale `i` selector left over from an older icon-font markup, so it silently had no effect. Switched the icon to `fill: currentColor` so it follows its wrapper's `color`, and pointed the placeholder-color control's CSS at the wrapper that actually exists in the markup today.

Both fixes are applied identically to the server-rendered CSS (`class-colormag-dynamic-builder-css.php` / compiled `style.css`/`style-rtl.css`) and the customizer's live-preview JS (`cm-customize-preview.js`), so the instant preview while adjusting a control matches the published output. All CMAG-710 CSS only emits when a custom Icon Size is actually set, so default/unconfigured sites are unaffected.

## Jira
**Jira:** [CMAG-710](https://themegrill.atlassian.net/browse/CMAG-710)
**Jira:** [CMAG-715](https://themegrill.atlassian.net/browse/CMAG-715)

## Test plan
- [x] Reproduced both CMAG-710 symptoms first: Search Box button computed `width: 60px` / `height: 48px` (hardcoded) at Icon Size = 60px; Icon Inside Search svg spilled ~6.5px above / ~5.4px below a 48px input at Icon Size = 60px
- [x] After fix: Search Box button computes `60x60px` (also verified at 40px) matching Icon Size
- [x] After fix: Icon Inside Search icon fully contained within the input's bounds at 60px and 45px (no spill)
- [x] Verified both CMAG-710 fixes in the server-rendered/published CSS and the customizer's instant live-preview (`postMessage`, no page reload)
- [x] Verified the Normal Search toggle icon (already working) is unaffected — still resizes correctly
- [x] Verified default/unconfigured Icon Size renders CSS identical to before this change (no regression)
- [x] Reproduced CMAG-715: svg `fill: rgb(255,255,255)` on an input with `background-color: rgb(255,255,255)` — invisible
- [x] After fix: setting Header Search Placeholder Color to a test color updates the icon's fill to match, in both live-preview and published output (previously had no effect)
- [x] Verified the placeholder text color itself (unrelated part of the same CSS rule) is unaffected — no regression
- [x] Confirmed no other code references the removed stale `i` selector

[CMAG-710]: https://themegrill.atlassian.net/browse/CMAG-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ