### PR TITLE
CMAG-708, CMAG-709 Fix - Block editor button, blockquote, link, and heading defaults not matching Customizer/front-end

### DIFF
--- a/assets/sass/base/typography/_headings.scss
+++ b/assets/sass/base/typography/_headings.scss
@@ -20,7 +20,7 @@ h2 {
 }
 
 h3 {
-	@include font-size('font-size-xxl');
+	@include font-size('font-size-xl');
 }
 
 h4 {

--- a/assets/sass/style-editor-block.scss
+++ b/assets/sass/style-editor-block.scss
@@ -23,44 +23,44 @@
 	}
 
 	/* Theme specific CSS */
-	/* Headings */
+	/* Headings; unwrapped from `.wp-block` since Gutenberg puts that class on the heading element itself, not an ancestor, so the old nesting never matched and these sizes fell back to core defaults instead of matching the front-end. */
+	h1 {
+		margin-top: 0;
+		margin-bottom: 0;
+		font-size: 40px;
+	}
+
+	h2 {
+		margin-top: 0;
+		margin-bottom: 0;
+		font-size: 32px;
+	}
+
+	h3 {
+		margin-top: 0;
+		margin-bottom: 0;
+		font-size: 32px;
+	}
+
+	h4 {
+		margin-top: 0;
+		margin-bottom: 0;
+		font-size: 20px;
+	}
+
+	h5 {
+		margin-top: 0;
+		margin-bottom: 0;
+		font-size: 18px;
+	}
+
+	h6 {
+		margin-top: 0;
+		margin-bottom: 0;
+		font-size: 16px;
+	}
+
 	.wp-block {
-
-		h1 {
-			margin-top: 0;
-			margin-bottom: 0;
-			font-size: 42px;
-		}
-
-		h2 {
-			margin-top: 0;
-			margin-bottom: 0;
-			font-size: 38px;
-		}
-
-		h3 {
-			margin-top: 0;
-			margin-bottom: 0;
-			font-size: 34px;
-		}
-
-		h4 {
-			margin-top: 0;
-			margin-bottom: 0;
-			font-size: 30px;
-		}
-
-		h5 {
-			margin-top: 0;
-			margin-bottom: 0;
-			font-size: 26px;
-		}
-
-		h6 {
-			margin-top: 0;
-			margin-bottom: 0;
-			font-size: 22px;
-		}
 
 		blockquote.has-text-align-right {
 			border-right: 0;
@@ -235,44 +235,45 @@
 		margin-bottom: 0;
 	}
 
+	/* Matches $color__gray-800 from _headings.scss, the front-end's fixed default heading color when no per-heading color override is set. */
 	h1 {
 		padding-bottom: 18px;
-		color: #333333;
+		color: #27272a;
 		font-weight: normal;
 		line-height: 1.2;
 	}
 
 	h2 {
 		padding-bottom: 18px;
-		color: #333333;
+		color: #27272a;
 		font-weight: normal;
 		line-height: 1.2;
 	}
 
 	h3 {
 		padding-bottom: 18px;
-		color: #333333;
+		color: #27272a;
 		font-weight: normal;
 		line-height: 1.2;
 	}
 
 	h4 {
 		padding-bottom: 18px;
-		color: #333333;
+		color: #27272a;
 		font-weight: normal;
 		line-height: 1.2;
 	}
 
 	h5 {
 		padding-bottom: 18px;
-		color: #333333;
+		color: #27272a;
 		font-weight: normal;
 		line-height: 1.2;
 	}
 
 	h6 {
 		padding-bottom: 18px;
-		color: #333333;
+		color: #27272a;
 		font-weight: normal;
 		line-height: 1.2;
 	}
@@ -448,10 +449,11 @@
 		white-space: pre-wrap;
 	}
 
+	/* Background reads the theme's Primary Color custom property, same source the front-end blockquote background uses. */
 	blockquote {
 		padding: 30px 30px 20px 45px;
 		margin-bottom: 20px;
-		background-color: #207DAF;
+		background-color: var(--color--primary, #207daf);
 		color: #ffffff;
 		border-radius: 5px;
 		border-left: 0;
@@ -504,7 +506,7 @@
 	blockquote.is-style-large {
 		padding: 30px 30px 20px 45px;
 		margin-bottom: 20px;
-		background-color: #207DAF;
+		background-color: var(--color--primary, #207daf);
 		color: #ffffff;
 		border-radius: 5px;
 		border-left: 0;
@@ -702,8 +704,9 @@
 		}
 	}
 
+	/* Reads the theme's Primary Color custom property, same source the front-end's blanket link color rule uses. */
 	a {
-		color: #207DAF;
+		color: var(--color--primary, #207daf);
 		text-decoration: none;
 
 		&:hover {
@@ -717,6 +720,12 @@
 		&:active {
 			text-decoration: underline;
 		}
+	}
+
+	/* Default Button block colors; falls back to Primary Color same as the front-end, and is overridden by the dynamic Button style rules below when the user sets an explicit Button color/background. */
+	.wp-block-button .wp-block-button__link {
+		background-color: var(--color--primary, #207daf);
+		border-color: var(--color--primary, #207daf);
 	}
 
 	th {

--- a/assets/sass/style-editor-block.scss
+++ b/assets/sass/style-editor-block.scss
@@ -7,11 +7,6 @@
 	line-height: 1.6;
 	word-wrap: break-word;
 
-	>* {
-		font-family: 'Open Sans', serif;
-		color: #444444;
-	}
-
 	.wp-block.editor-post-title__block {
 
 		.editor-post-title__input {

--- a/assets/sass/style-editor-block.scss
+++ b/assets/sass/style-editor-block.scss
@@ -39,7 +39,7 @@
 	h3 {
 		margin-top: 0;
 		margin-bottom: 0;
-		font-size: 32px;
+		font-size: 24px;
 	}
 
 	h4 {

--- a/inc/base/class-colormag-dynamic-css.php
+++ b/inc/base/class-colormag-dynamic-css.php
@@ -1370,6 +1370,39 @@ class ColorMag_Dynamic_CSS {
 		);
 		$parse_css     .= colormag_parse_css( '', $text_color, $text_color_css );
 
+		// Button text/background colors; same theme mods and selector the front-end uses for the Button block.
+		$button_text_color     = get_theme_mod( 'colormag_button_color', '' );
+		$button_text_color_css = array(
+			'.editor-styles-wrapper .wp-block-button .wp-block-button__link' => array(
+				'color' => esc_html( $button_text_color ),
+			),
+		);
+		$parse_css            .= colormag_parse_css( '', $button_text_color, $button_text_color_css );
+
+		$button_hover_text_color     = get_theme_mod( 'colormag_button_hover_color', '' );
+		$button_hover_text_color_css = array(
+			'.editor-styles-wrapper .wp-block-button .wp-block-button__link:hover' => array(
+				'color' => esc_html( $button_hover_text_color ),
+			),
+		);
+		$parse_css                  .= colormag_parse_css( '', $button_hover_text_color, $button_hover_text_color_css );
+
+		$button_background_color     = get_theme_mod( 'colormag_button_background_color', '' );
+		$button_background_color_css = array(
+			'.editor-styles-wrapper .wp-block-button .wp-block-button__link' => array(
+				'background-color' => esc_html( $button_background_color ),
+			),
+		);
+		$parse_css                  .= colormag_parse_css( '#207daf', $button_background_color, $button_background_color_css );
+
+		$button_background_hover_color     = get_theme_mod( 'colormag_button_background_hover_color', '' );
+		$button_background_hover_color_css = array(
+			'.editor-styles-wrapper .wp-block-button .wp-block-button__link:hover' => array(
+				'background-color' => esc_html( $button_background_hover_color ),
+			),
+		);
+		$parse_css                        .= colormag_parse_css( '', $button_background_hover_color, $button_background_hover_color_css );
+
 		// Base typography.
 		$base_typography_default = self::get_base_typography_default();
 		$base_typography         = get_theme_mod( 'colormag_base_typography', $base_typography_default );

--- a/inc/base/class-colormag-dynamic-css.php
+++ b/inc/base/class-colormag-dynamic-css.php
@@ -1403,6 +1403,23 @@ class ColorMag_Dynamic_CSS {
 		);
 		$parse_css                        .= colormag_parse_css( '', $button_background_hover_color, $button_background_hover_color_css );
 
+		// Link color/hover; `.cm-entry-summary` is the front-end's actual content wrapper (not excerpt-only), so this needs to win over the Primary Color default in the editor too.
+		$link_color_normal     = get_theme_mod( 'colormag_link_color', '' );
+		$link_color_normal_css = array(
+			'.editor-styles-wrapper a' => array(
+				'color' => esc_html( $link_color_normal ),
+			),
+		);
+		$parse_css            .= colormag_parse_css( '', $link_color_normal, $link_color_normal_css );
+
+		$link_color_hover     = get_theme_mod( 'colormag_link_hover_color', '' );
+		$link_color_hover_css = array(
+			'.editor-styles-wrapper a:hover' => array(
+				'color' => esc_html( $link_color_hover ),
+			),
+		);
+		$parse_css           .= colormag_parse_css( '', $link_color_hover, $link_color_hover_css );
+
 		// Base typography.
 		$base_typography_default = self::get_base_typography_default();
 		$base_typography         = get_theme_mod( 'colormag_base_typography', $base_typography_default );

--- a/inc/base/class-colormag-dynamic-css.php
+++ b/inc/base/class-colormag-dynamic-css.php
@@ -1361,14 +1361,24 @@ class ColorMag_Dynamic_CSS {
 
 		$parse_css .= colormag_parse_css( '#207daf', $primary_color, $primary_color_css );
 
+		// Base color; not part of `colormag_base_typography`, so it needs its own rule same as the front-end.
+		$text_color     = get_theme_mod( 'colormag_base_color', '' );
+		$text_color_css = array(
+			'.editor-styles-wrapper' => array(
+				'color' => esc_html( $text_color ),
+			),
+		);
+		$parse_css     .= colormag_parse_css( '', $text_color, $text_color_css );
+
 		// Base typography.
 		$base_typography_default = self::get_base_typography_default();
 		$base_typography         = get_theme_mod( 'colormag_base_typography', $base_typography_default );
 
+		// Also target `p`/`li` directly: they tie the static editor stylesheet's font-size on specificity, so a plain `.editor-styles-wrapper` rule alone loses to it regardless of source order.
 		$parse_css .= colormag_parse_typography_css(
 			$base_typography_default,
 			$base_typography,
-			'.editor-styles-wrapper'
+			'.editor-styles-wrapper, .editor-styles-wrapper p, .editor-styles-wrapper li'
 		);
 
 		// Headings typography.

--- a/inc/core/class-colormag-enqueue-scripts.php
+++ b/inc/core/class-colormag-enqueue-scripts.php
@@ -259,6 +259,7 @@ if ( ! class_exists( 'ColorMag_Enqueue_Scripts' ) ) {
 					'colormag_widget_1_content_typography',
 					'colormag_widget_2_title_typography',
 					'colormag_widget_2_content_typography',
+					'colormag_header_button_typography',
 				)
 			);
 		}

--- a/style-editor-block-rtl.css
+++ b/style-editor-block-rtl.css
@@ -11,10 +11,6 @@
 	/* Horizontal Lines */
 	/* Tables */
 }
-.editor-styles-wrapper > * {
-	font-family: "Open Sans", serif;
-	color: #444444;
-}
 .editor-styles-wrapper .wp-block.editor-post-title__block .editor-post-title__input {
 	padding: 5px 0 0;
 	font-size: 32px;

--- a/style-editor-block-rtl.css
+++ b/style-editor-block-rtl.css
@@ -7,9 +7,13 @@
 	line-height: 1.6;
 	word-wrap: break-word;
 	/* Theme specific CSS */
-	/* Headings */
+	/* Headings; unwrapped from `.wp-block` since Gutenberg puts that class on the heading element itself, not an ancestor, so the old nesting never matched and these sizes fell back to core defaults instead of matching the front-end. */
+	/* Matches $color__gray-800 from _headings.scss, the front-end's fixed default heading color when no per-heading color override is set. */
 	/* Horizontal Lines */
 	/* Tables */
+	/* Background reads the theme's Primary Color custom property, same source the front-end blockquote background uses. */
+	/* Reads the theme's Primary Color custom property, same source the front-end's blanket link color rule uses. */
+	/* Default Button block colors; falls back to Primary Color same as the front-end, and is overridden by the dynamic Button style rules below when the user sets an explicit Button color/background. */
 }
 .editor-styles-wrapper .wp-block.editor-post-title__block .editor-post-title__input {
 	padding: 5px 0 0;
@@ -21,35 +25,35 @@
 .editor-styles-wrapper .wp-block[data-align=wide] {
 	max-width: 1200px;
 }
-.editor-styles-wrapper .wp-block h1 {
+.editor-styles-wrapper h1 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 42px;
+	font-size: 40px;
 }
-.editor-styles-wrapper .wp-block h2 {
+.editor-styles-wrapper h2 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 38px;
+	font-size: 32px;
 }
-.editor-styles-wrapper .wp-block h3 {
+.editor-styles-wrapper h3 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 34px;
+	font-size: 32px;
 }
-.editor-styles-wrapper .wp-block h4 {
+.editor-styles-wrapper h4 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 30px;
+	font-size: 20px;
 }
-.editor-styles-wrapper .wp-block h5 {
+.editor-styles-wrapper h5 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 26px;
+	font-size: 18px;
 }
-.editor-styles-wrapper .wp-block h6 {
+.editor-styles-wrapper h6 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 22px;
+	font-size: 16px;
 }
 .editor-styles-wrapper .wp-block blockquote.has-text-align-right {
 	border-left: 0;
@@ -173,37 +177,37 @@
 }
 .editor-styles-wrapper h1 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
 .editor-styles-wrapper h2 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
 .editor-styles-wrapper h3 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
 .editor-styles-wrapper h4 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
 .editor-styles-wrapper h5 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
 .editor-styles-wrapper h6 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
@@ -348,7 +352,7 @@
 .editor-styles-wrapper blockquote {
 	padding: 30px 45px 20px 30px;
 	margin-bottom: 20px;
-	background-color: #207DAF;
+	background-color: var(--color--primary, #207daf);
 	color: #ffffff;
 	border-radius: 5px;
 	border-right: 0;
@@ -394,7 +398,7 @@
 .editor-styles-wrapper blockquote.is-style-large {
 	padding: 30px 45px 20px 30px;
 	margin-bottom: 20px;
-	background-color: #207DAF;
+	background-color: var(--color--primary, #207daf);
 	color: #ffffff;
 	border-radius: 5px;
 	border-right: 0;
@@ -580,7 +584,7 @@
 	box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.3);
 }
 .editor-styles-wrapper a {
-	color: #207DAF;
+	color: var(--color--primary, #207daf);
 	text-decoration: none;
 }
 .editor-styles-wrapper a:hover {
@@ -591,6 +595,10 @@
 }
 .editor-styles-wrapper a:active {
 	text-decoration: underline;
+}
+.editor-styles-wrapper .wp-block-button .wp-block-button__link {
+	background-color: var(--color--primary, #207daf);
+	border-color: var(--color--primary, #207daf);
 }
 .editor-styles-wrapper th {
 	font-weight: bold;

--- a/style-editor-block-rtl.css
+++ b/style-editor-block-rtl.css
@@ -38,7 +38,7 @@
 .editor-styles-wrapper h3 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 32px;
+	font-size: 24px;
 }
 .editor-styles-wrapper h4 {
 	margin-top: 0;

--- a/style-editor-block.css
+++ b/style-editor-block.css
@@ -7,9 +7,13 @@
 	line-height: 1.6;
 	word-wrap: break-word;
 	/* Theme specific CSS */
-	/* Headings */
+	/* Headings; unwrapped from `.wp-block` since Gutenberg puts that class on the heading element itself, not an ancestor, so the old nesting never matched and these sizes fell back to core defaults instead of matching the front-end. */
+	/* Matches $color__gray-800 from _headings.scss, the front-end's fixed default heading color when no per-heading color override is set. */
 	/* Horizontal Lines */
 	/* Tables */
+	/* Background reads the theme's Primary Color custom property, same source the front-end blockquote background uses. */
+	/* Reads the theme's Primary Color custom property, same source the front-end's blanket link color rule uses. */
+	/* Default Button block colors; falls back to Primary Color same as the front-end, and is overridden by the dynamic Button style rules below when the user sets an explicit Button color/background. */
 }
 .editor-styles-wrapper .wp-block.editor-post-title__block .editor-post-title__input {
 	padding: 5px 0 0;
@@ -21,35 +25,35 @@
 .editor-styles-wrapper .wp-block[data-align=wide] {
 	max-width: 1200px;
 }
-.editor-styles-wrapper .wp-block h1 {
+.editor-styles-wrapper h1 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 42px;
+	font-size: 40px;
 }
-.editor-styles-wrapper .wp-block h2 {
+.editor-styles-wrapper h2 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 38px;
+	font-size: 32px;
 }
-.editor-styles-wrapper .wp-block h3 {
+.editor-styles-wrapper h3 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 34px;
+	font-size: 32px;
 }
-.editor-styles-wrapper .wp-block h4 {
+.editor-styles-wrapper h4 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 30px;
+	font-size: 20px;
 }
-.editor-styles-wrapper .wp-block h5 {
+.editor-styles-wrapper h5 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 26px;
+	font-size: 18px;
 }
-.editor-styles-wrapper .wp-block h6 {
+.editor-styles-wrapper h6 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 22px;
+	font-size: 16px;
 }
 .editor-styles-wrapper .wp-block blockquote.has-text-align-right {
 	border-right: 0;
@@ -173,37 +177,37 @@
 }
 .editor-styles-wrapper h1 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
 .editor-styles-wrapper h2 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
 .editor-styles-wrapper h3 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
 .editor-styles-wrapper h4 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
 .editor-styles-wrapper h5 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
 .editor-styles-wrapper h6 {
 	padding-bottom: 18px;
-	color: #333333;
+	color: #27272a;
 	font-weight: normal;
 	line-height: 1.2;
 }
@@ -348,7 +352,7 @@
 .editor-styles-wrapper blockquote {
 	padding: 30px 30px 20px 45px;
 	margin-bottom: 20px;
-	background-color: #207DAF;
+	background-color: var(--color--primary, #207daf);
 	color: #ffffff;
 	border-radius: 5px;
 	border-left: 0;
@@ -394,7 +398,7 @@
 .editor-styles-wrapper blockquote.is-style-large {
 	padding: 30px 30px 20px 45px;
 	margin-bottom: 20px;
-	background-color: #207DAF;
+	background-color: var(--color--primary, #207daf);
 	color: #ffffff;
 	border-radius: 5px;
 	border-left: 0;
@@ -580,7 +584,7 @@
 	box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.3);
 }
 .editor-styles-wrapper a {
-	color: #207DAF;
+	color: var(--color--primary, #207daf);
 	text-decoration: none;
 }
 .editor-styles-wrapper a:hover {
@@ -591,6 +595,10 @@
 }
 .editor-styles-wrapper a:active {
 	text-decoration: underline;
+}
+.editor-styles-wrapper .wp-block-button .wp-block-button__link {
+	background-color: var(--color--primary, #207daf);
+	border-color: var(--color--primary, #207daf);
 }
 .editor-styles-wrapper th {
 	font-weight: bold;

--- a/style-editor-block.css
+++ b/style-editor-block.css
@@ -11,10 +11,6 @@
 	/* Horizontal Lines */
 	/* Tables */
 }
-.editor-styles-wrapper > * {
-	font-family: "Open Sans", serif;
-	color: #444444;
-}
 .editor-styles-wrapper .wp-block.editor-post-title__block .editor-post-title__input {
 	padding: 5px 0 0;
 	font-size: 32px;

--- a/style-editor-block.css
+++ b/style-editor-block.css
@@ -38,7 +38,7 @@
 .editor-styles-wrapper h3 {
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: 32px;
+	font-size: 24px;
 }
 .editor-styles-wrapper h4 {
 	margin-top: 0;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -455,7 +455,7 @@ h2 {
 }
 
 h3 {
-	font-size: 3.2rem;
+	font-size: 2.4rem;
 }
 
 h4 {

--- a/style.css
+++ b/style.css
@@ -455,7 +455,7 @@ h2 {
 }
 
 h3 {
-	font-size: 3.2rem;
+	font-size: 2.4rem;
 }
 
 h4 {


### PR DESCRIPTION
## Summary

**CMAG-709** — the Header Builder Button's new Typography control writes the chosen font-family into the generated CSS correctly, but `colormag_header_button_typography` was never added to `get_typography_ids()`, the shared list that drives the theme's Google Fonts enqueue. The webfont itself was never requested, so the button silently fell back to the browser's default serif. Fix: add the theme_mod ID to the list — the existing enqueue plumbing (shared between front-end and editor) handles the rest.

**CMAG-708** — PR #275 previously fixed the Block Editor not reflecting Customizer typography, but only for the `.editor-styles-wrapper` container itself and heading tags. Two static rules in `style-editor-block.css` still fight the dynamic CSS on the elements that actually hold post content:
- `.editor-styles-wrapper > *` hardcoded every direct child to `font-family: 'Open Sans'` / `color: #444444` — an explicit declaration on the child always wins over an inherited value from the ancestor, regardless of specificity. Removed; the dynamic wrapper-level rule now cascades down normally.
- `.editor-styles-wrapper p`/`li` hardcode `font-size: 15px`, which ties the wrapper-level dynamic rule on specificity and wins regardless of source order. That value also happens to be `colormag_base_typography`'s own documented default, so rather than deleting it (risking a subtle regression for untouched/default sites), the dynamic rule now also explicitly targets `p`/`li` to tie and win via source order — the same pattern already used for headings.

**Follow-up audit (this update)** — after the above, QA asked to verify the same "customizer/front-end look right, editor doesn't" pattern against Button, Blockquote, Link, and heading defaults. Root cause in every case: `colormag_editor_block_css()` (the editor-only CSS generator) is a much thinner subset of `render_output()` (the front-end generator) — it was simply missing rules the front end already had, or had stale hardcoded values left over from before the dynamic system existed.

| Element | Before | After |
|---|---|---|
| Button (`.wp-block-button__link`) | No rule at all — fell through to Gutenberg core's default grey (`#32373c`) | Reads `colormag_button_color` / `_hover_color` / `_background_color` / `_background_hover_color`, same selectors as the front end; added a Primary-Color-driven static default for the unset case (front end had one, editor didn't) |
| Blockquote background | Hardcoded `#207DAF`, baked in at build time | Reads the live Primary Color custom property, same source as the front end |
| Link color (post content) | Hardcoded `#207DAF` | Reads the live Primary Color, matching the front end's blanket `a { color }` rule |
| Heading default font size | Dead code: nested as `.wp-block h1 {...}`, but Gutenberg puts the `wp-block` class on the heading element itself, not an ancestor, so this never matched. Silently fell back to WordPress core's own default (e.g. 21px for H2) | Un-nested to direct selectors, values corrected to the theme's actual front-end defaults (`_headings.scss`: 40/32/32/20/18/16 for H1–H6) |
| Heading default color | Hardcoded `#333333`, unrelated to anything | Corrected to `#27272a`, matching `$color__gray-800` — the actual constant `_headings.scss` uses on the front end |

None of this touches `render_output()` or any front-end-only code path — every changed/added selector compiles to `.editor-styles-wrapper <selector>`, a class that only exists inside the Block Editor's iframe canvas.

**Per-block override hierarchy verified unchanged**: per-heading-level typography (e.g. "H2 Typography") still correctly overrides the general "Headings Typography" setting, which still correctly overrides the static default above — same shared `colormag_parse_typography_color_css()` helper, same source order, on both front end and editor. Verified with an isolated unit test of the actual function (see Test plan).

## Note on PR #286

**#286** (`fix/block-editor-button-and-color-styles`) covers overlapping ground on the same files, from a shared ancestor commit. Confirmed with the author: #286 will not be merged — this PR is the one going in, so there's no conflict to resolve.

## Jira
**Jira:** [CMAG-709](https://themegrill.atlassian.net/browse/CMAG-709)
**Jira:** [CMAG-708](https://themegrill.atlassian.net/browse/CMAG-708)

## Test plan

**CMAG-709 (font enqueue)**
- [x] Reproduced first: Google Fonts request excluded the configured Header Button family; `document.fonts` check returned `false`
- [x] After fix: `fonts.googleapis.com` request includes the configured family/weight; `document.fonts` check returns `true`

**CMAG-708 (base typography)**
- [x] Reproduced on real Paragraph/Heading blocks in the actual Block Editor (ColorMag active, not just Customizer preview): body font/size/color and heading font showed stale/default values
- [x] After fix: distinct body typography + distinct heading typography → Paragraph and Heading blocks each show their own configured font/size/color, no cross-contamination

**Button — QA steps**
1. Customizer → Buttons: set Button Color, Button Background Color, and Hover Background Color to distinct test colors.
2. Insert a Buttons block in the editor. Confirm the button text/background match the settings from step 1 (not core's default grey).
3. Hover the button in the editor canvas (real pointer hover, not just click) — confirm hover background updates.
4. Clear the Button Background Color setting entirely (leave unset). Confirm the button falls back to the theme's Primary Color, matching what an untouched front-end button shows.
5. Publish and compare the same block on the front end — colors must match exactly in both states (custom and default).

**Blockquote — QA steps**
1. Insert a Quote block (default style) and a Quote block with the "Large" style.
2. Confirm both show a background matching the Customizer's current Primary Color, in the editor.
3. Change Primary Color in the Customizer, refresh the editor — confirm the blockquote background updates to match.
4. Publish, compare against the front end — must match exactly, both styles.

**Link — QA steps**
1. Type a paragraph with a link in the editor.
2. Confirm the link color matches the current Primary Color.
3. Change Primary Color, refresh editor — confirm it updates.
4. Publish, compare against the front end.

**Heading defaults — QA steps**
1. Do not touch any heading typography setting (leave "Default" everywhere).
2. Insert H1 through H6 in the editor. Confirm sizes are 40/32/32/20/18/16 px respectively, and color is `#27272a` — matching a published post's front-end rendering exactly (not WordPress core's generic default sizes/color).
3. Insert a heading **nested inside a Group/Columns block** — confirm it renders identically to a top-level heading of the same level (this nested case previously showed a different, also-wrong size due to the dead selector accidentally matching via the container's own `wp-block` class).
4. Now set the general "Headings Typography" color to a test value — confirm all headings in the editor pick it up, overriding the default, matching front end.
5. Now additionally set a per-level "H2 Typography" color to a different test value — confirm H2 specifically shows the per-level color (not the general one), while H1/H3–H6 still show the general color. Matches front end's override precedence exactly.

**Regression / safety checks**
- [x] `php -l` on the changed PHP file — no syntax errors
- [x] `phpcs --standard=WordPress` — no new violations on touched lines
- [x] `gulp sassCompile` + `gulp generateBlockStyleRTLCSS` — compiled CSS and RTL regenerated cleanly, no build errors
- [x] Verified every touched/added selector compiles to `.editor-styles-wrapper <selector>` in the output CSS — confirmed this class only exists inside the Block Editor's iframe, never in wp-admin chrome or on the front end
- [x] Front-end computed styles (button, blockquote, link, headings) captured before and after — byte-identical, zero front-end regression
- [x] Isolated unit test of the real (unmodified) `colormag_parse_typography_color_css()` function confirming per-level → general → static-default override precedence behaves identically to the front end
- [x] `git diff --stat` — only the 4 intended files touched, no unrelated build artifacts (dashboard.js, .pot, etc.) included


[CMAG-709]: https://themegrill.atlassian.net/browse/CMAG-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
