### PR TITLE
CMAG-732 Fix - Search icon background overflows input border radius in Icon Inside Search

### DIFF
--- a/inc/base/class-colormag-dynamic-builder-css.php
+++ b/inc/base/class-colormag-dynamic-builder-css.php
@@ -421,7 +421,7 @@ class ColorMag_Dynamic_Builder_CSS {
 		$parse_builder_css .= colormag_parse_slider_css(
 			$full_search_border_radius_default,
 			$header_button_border_radius,
-			'.cm-search-icon-in-input-right .search-wrap input',
+			'.cm-search-icon-in-input-right .search-wrap input, .cm-search-icon-in-input-right .search-wrap, .cm-search-icon-in-input-right .search-icon-input-right',
 			'border-radius'
 		);
 

--- a/inc/customizer/assets/js/cm-customize-preview.js
+++ b/inc/customizer/assets/js/cm-customize-preview.js
@@ -1037,7 +1037,7 @@
 
 				case 'colormag_header_search_border_radius':
 					css = colormagGenerateSliderCSS(
-						'.cm-search-icon-in-input-right .search-wrap input',
+						'.cm-search-icon-in-input-right .search-wrap input, .cm-search-icon-in-input-right .search-wrap, .cm-search-icon-in-input-right .search-icon-input-right',
 						'border-radius',
 						value,
 					);


### PR DESCRIPTION
## Summary

For the **Icon Inside Search** header search type, setting a **Search Button > Background** color gives the icon a badge-style background, and a **Border Radius** can be set on the search input. The Border Radius control, however, only ever styled the `input` element — the icon's badge stayed a plain square (`border-radius: 0`) and the clipping `.search-wrap` container kept its hardcoded `4px` radius from the base styles.

Since the badge sits on top of the input at the same corner, its square corners visibly spilled past the input's much-more-rounded pill shape once a custom Border Radius was set (most obvious at large radius values, where the input becomes a near-circular pill but the badge stays a hard square).

## Fix

Reuse the same `colormag_header_search_border_radius` value for:
- `.cm-search-icon-in-input-right .search-icon-input-right` — rounds the badge itself so it matches the input's roundness (a circle at extreme radius values, matching the reported screenshot).
- `.cm-search-icon-in-input-right .search-wrap` — keeps the clipping container's radius in sync as a containment safety net.

Applied identically to the server-rendered CSS (`class-colormag-dynamic-builder-css.php`) and the customizer's live-preview JS (`cm-customize-preview.js`), so the instant preview matches the published output. The CSS only emits when a custom Border Radius is actually set, so default/unconfigured sites are unaffected.

## Test plan
- [x] Reproduced: Icon Inside Search + red Search Button Background + Border Radius 30px/598px — icon badge's square corners overflowed past the input's rounded/near-circular shape
- [x] After fix: badge renders as a rounded rect / full circle matching the input's radius, fully contained within the input at both 30px and 598px
- [x] Verified in the customizer's instant live preview (postMessage, no page reload) and the published front-end output
- [x] Verified default/unconfigured Border Radius renders CSS identical to before this change (no regression)
- [x] Verified other search types (Normal Search, Search Box) are unaffected

## Jira
**Jira:** [CMAG-732](https://themegrill.atlassian.net/browse/CMAG-732)

[CMAG-732]: https://themegrill.atlassian.net/browse/CMAG-732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ