### PR TITLE
Fix -Use core 'large' image size for single post featured image to fix blurry rendering

### DIFF
--- a/assets/sass/components/entry/_thumbnail.scss
+++ b/assets/sass/components/entry/_thumbnail.scss
@@ -6,3 +6,13 @@
 		position: relative;
 	}
 }
+
+.single-post .cm-post-content > .cm-featured-image {
+
+	img {
+		width: 100%;
+		height: auto;
+		aspect-ratio: 800 / 445;
+		object-fit: cover;
+	}
+}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3055,6 +3055,14 @@ Styles for separating single posts loaded from ajax call.
 	position: relative;
 }
 
+.single-post .cm-post-content > .cm-featured-image img {
+	width: 100%;
+	height: auto;
+	aspect-ratio: 800/445;
+	-o-object-fit: cover;
+	   object-fit: cover;
+}
+
 /* Widgets.
 --------------------------------------------- */
 /* Advertisement Widget.

--- a/style.css
+++ b/style.css
@@ -3055,6 +3055,14 @@ Styles for separating single posts loaded from ajax call.
 	position: relative;
 }
 
+.single-post .cm-post-content > .cm-featured-image img {
+	width: 100%;
+	height: auto;
+	aspect-ratio: 800/445;
+	-o-object-fit: cover;
+	   object-fit: cover;
+}
+
 /* Widgets.
 --------------------------------------------- */
 /* Advertisement Widget.

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -53,10 +53,10 @@ $image_popup_url = wp_get_attachment_url( $image_popup_id );
 						?>
 						<div class="cm-featured-image">
 							<?php if ( 1 == get_theme_mod( 'colormag_enable_lightbox', 0 ) ) : ?>
-								<a href="<?php echo esc_url( $image_popup_url ); ?>" class="image-popup"><?php the_post_thumbnail( 'colormag-featured-image' ); ?></a>
+								<a href="<?php echo esc_url( $image_popup_url ); ?>" class="image-popup"><?php the_post_thumbnail( 'large' ); ?></a>
 								<?php
 							else :
-								the_post_thumbnail( 'colormag-featured-image' );
+								the_post_thumbnail( 'large' );
 							endif;
 							?>
 						</div>


### PR DESCRIPTION
## Summary
Single posts rendered the featured image at a hardcoded, hard-cropped 800x445 size with no other registered size sharing that aspect ratio, so WordPress could not generate a `srcset` for it — the image had exactly one candidate, 800px wide, regardless of display density or layout width. On any standard Retina/2x display this is a guaranteed pixel shortfall, which is what caused the reported blur. Switches to WordPress core's `large` size, which already gets a correct multi-candidate `srcset` since it's proportionally derived from the original. This also matches what colormag-pro already defaults to.

## How to test
1. Set a large, high-resolution image as a post's featured image.
2. View the single post page and inspect the featured image's `srcset` attribute — it should now list multiple width candidates instead of none.
3. Confirm the image renders sharply on a high-density (2x) display/emulation.

Jira: https://themegrill.atlassian.net/browse/CMAG-743