### PR TITLE
Fix - Header Builder main row column snapped to a fixed width when it held a second component (CMAG-306)

### DIFF
--- a/assets/sass/base/elements/_header_builder.scss
+++ b/assets/sass/base/elements/_header_builder.scss
@@ -129,15 +129,7 @@
 			align-items: center;
 			height: 100%;
 
-			// Only constrain the column's width when it holds more than one
-			// component (e.g. logo + header widget from an imported demo).
-			// A single component - most commonly just the logo - must stay
-			// free to size itself, otherwise a large configured logo gets
-			// squeezed down to fit a fixed 30% slice of the row (CMAG-650
-			// regression).
-			&.cm-header-col--has-multiple {
-				flex-basis: 30%;
-			}
+			// No flex-basis: a fixed width broke this column (CMAG-306, CMAG-650).
 		}
 
 		.cm-header-center-col {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1077,9 +1077,6 @@ table td {
 	align-items: center;
 	height: 100%;
 }
-.cm-header-builder .cm-main-row .cm-header-left-col.cm-header-col--has-multiple {
-	flex-basis: 30%;
-}
 .cm-header-builder .cm-main-row .cm-header-center-col {
 	display: flex;
 	gap: 16px;

--- a/style.css
+++ b/style.css
@@ -1077,9 +1077,6 @@ table td {
 	align-items: center;
 	height: 100%;
 }
-.cm-header-builder .cm-main-row .cm-header-left-col.cm-header-col--has-multiple {
-	flex-basis: 30%;
-}
 .cm-header-builder .cm-main-row .cm-header-center-col {
 	display: flex;
 	gap: 16px;


### PR DESCRIPTION
Fixes #306

## Summary

The main row's left column carried a hard-coded `flex-basis: 30%` whenever it held more than one component. Adding a second element (logo + widget, common after a demo import) made the column snap to a fixed width, shifting the rest of the header, with no way to adjust it from the Customizer.

The 30% was a leftover from the legacy pre-builder header (`.cm-header-col-1`), which split the row 30/70 for logo + ad. It has no meaning in the three-column builder row.

Removed the rule so all three columns size to their content.

## Changes

- `assets/sass/base/elements/_header_builder.scss` — removed the `&.cm-header-col--has-multiple { flex-basis: 30% }` block
- `style.css`, `style-rtl.css` — regenerated via `gulp styles`

No PHP changed. `inc/builder-template-tags.php` still outputs the `cm-header-col--has-multiple` class, so any existing custom CSS keyed to it keeps working, and sites that want the old look can restore it with:

```css
.cm-header-builder .cm-main-row .cm-header-left-col.cm-header-col--has-multiple {
	flex-basis: 30%;
}
```

Single-element columns are untouched, so the CMAG-650 logo fix stays intact.

## How to test

1. Customizer → Header Builder → put **only the logo** in the main row's left column. Set a large logo. It should render full size (CMAG-650 guard — no regression).
2. Add a **second element** (e.g. a header widget) to that same left column. The column should size to its content instead of jumping to 30% of the row width, and the rest of the header should not shift.
3. Import a demo that ships a multi-element left column and confirm the header renders sanely.
4. Check the top and bottom rows are unaffected.
5. Check RTL (`style-rtl.css`) and mobile at ≤768px.

