### PR TITLE
Fix: pnpm install failing due to unapproved build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: true
+  core-js-pure: true


### PR DESCRIPTION
## Summary
- `pnpm-workspace.yaml` had placeholder text (`"set this to true or false"`) instead of real boolean values under `allowBuilds`, so pnpm never approved the native build scripts for `@parcel/watcher`, `core-js`, and `core-js-pure`.
- Every `pnpm install` was exiting with `ERR_PNPM_IGNORED_BUILDS`, which blocked `pnpm run build` since `wp-scripts` runs a dependency sync check (an internal `pnpm install`) before building.
- Fixed by setting the values to actual booleans (`true`), matching what `pnpm approve-builds --all` generates.

## Test plan
- [x] `pnpm install` exits 0 with no ignored-build errors
- [x] `pnpm run build` completes successfully (webpack compiles with only pre-existing, unrelated size-limit warnings)