### PR TITLE
Add PR review automation

### DIFF
--- a/.github/workflows/copilot-review-on-comment.yml
+++ b/.github/workflows/copilot-review-on-comment.yml
@@ -1,6 +1,8 @@
 name: Copilot review on comment
 
 on:
+  pull_request_target:
+    types: [opened]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
Adds the reusable PR-review workflow, called from wpeverest/.github. It requests Copilot as a reviewer when a PR opens, and lets accounts with write access or higher request a Copilot review by commenting `@tg-autopilot review`.