### PR TITLE
Fix swapped ad widget class names in Elementor map

### DIFF
--- a/inc/compatibility/elementor/elementor.php
+++ b/inc/compatibility/elementor/elementor.php
@@ -85,8 +85,8 @@ if ( ! function_exists( 'colormag_widgets_classes' ) ) :
 			'colormag_highlighted_posts_widget'       => 'widget_highlighted_posts widget_featured_meta',
 			'colormag_featured_posts_widget'          => 'widget_featured_posts widget_featured_meta',
 			'colormag_featured_posts_vertical_widget' => 'widget_featured_posts widget_featured_posts_vertical widget_featured_meta',
-			'colormag_728x90_advertisement_widget'    => 'widget_300x250_advertisement',
-			'colormag_300x250_advertisement_widget'   => 'widget_728x90_advertisement',
+			'colormag_728x90_advertisement_widget'    => 'widget_728x90_advertisement',
+			'colormag_300x250_advertisement_widget'   => 'widget_300x250_advertisement',
 			'colormag_125x125_advertisement_widget'   => 'widget_125x125_advertisement',
 		);
 


### PR DESCRIPTION
## What

`colormag_widgets_classes()` in `inc/compatibility/elementor/elementor.php` mapped the 728x90 advertisement widget to `widget_300x250_advertisement`, and the 300x250 widget to `widget_728x90_advertisement`. This swaps them back so each widget maps to its own class name.

## Why

The map is consumed by `colormag_widget_class_names()`, which feeds the `elementor/widgets/wordpress/widget_args` filter and classes the outer `<section class="widget …">` wrapper of widgets rendered through Elementor's Sidebar widget.

The transposition dates back to the file's first commit (`907e18ad`), which shipped several transposed pairs in the same map (weather/cta, video-playlist/exchange) — a copy-paste error rather than an intentional mapping. Those other pairs disappeared when the map was rewritten in `0e11156c`; these two survived it.

## Impact on rendered appearance: none

- Neither `widget_300x250_advertisement` nor `widget_728x90_advertisement` is styled anywhere in the theme. Both are absent from `style.css`, `style-rtl.css`, `dark.css`, `assets/css/*`, and every file under `assets/sass`. The only `.widget_`-prefixed selector left in the theme's styles is `.widget_call_to_action`.
- These are ColorMag 2.x legacy names that the 3.0 rewrite to `cm-*` prefixed classes left behind. The rest of the map points at equally unstyled names (`widget_featured_slider`, `widget_featured_meta`, `widget_125x125_advertisement`).
- The ads' actual styling comes from the inner markup each widget prints itself — `<div class="advertisement_728x90">` and `<div class="advertisement_300x250">` — which is hardcoded in the widgets' `widget()` methods and is unaffected by this map.

## Notes for review

- **Behavior change is limited to the wrapper's class attribute.** Sites that added custom CSS against the previous, incorrect output would be affected. Nothing in the theme itself relies on it.
- **Side effect, in the right direction:** the 300x250 widget declares `$this->widget_cssclass = 'widget_300x250_advertisement'`, so a normal (non-Elementor) sidebar already emits that class for it. The Elementor path was handing that class to the *728x90* widget instead; the two paths now agree. The 728x90 widget declares `cm-728x90-advertisemen-widget` (existing typo, left alone), so `widget_728x90_advertisement` is still emitted nowhere else — but it is now at least on the semantically correct widget.
- **Verification requires Elementor.** The change is only observable with Elementor active, a ColorMag advertisement widget placed through Elementor's Sidebar widget, and the wrapper element's `class` inspected. Because the mapped classes are unstyled, a screenshot comparison shows no difference by construction. There is no existing e2e coverage for the Elementor path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
