### PR TITLE
Add default spacing between featured image and title (colormag-pro#327)

### DIFF
--- a/assets/sass/components/entry/_thumbnail.scss
+++ b/assets/sass/components/entry/_thumbnail.scss
@@ -1,5 +1,6 @@
 .cm-featured-image {
 	text-align: center;
+	margin-bottom: length( 'l-8' );
 
 	a {
 		display: block;

--- a/assets/sass/components/entry/_thumbnail.scss
+++ b/assets/sass/components/entry/_thumbnail.scss
@@ -1,6 +1,9 @@
 .cm-featured-image {
 	text-align: center;
-	margin-bottom: length( 'l-8' );
+
+	&:not(:last-child) {
+		margin-bottom: length( 'l-8' );
+	}
 
 	a {
 		display: block;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3080,6 +3080,8 @@ Styles for separating single posts loaded from ajax call.
 
 .cm-featured-image {
 	text-align: center;
+}
+.cm-featured-image:not(:last-child) {
 	margin-bottom: 16px;
 }
 .cm-featured-image a {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3080,6 +3080,7 @@ Styles for separating single posts loaded from ajax call.
 
 .cm-featured-image {
 	text-align: center;
+	margin-bottom: 16px;
 }
 .cm-featured-image a {
 	display: block;

--- a/style.css
+++ b/style.css
@@ -3080,6 +3080,8 @@ Styles for separating single posts loaded from ajax call.
 
 .cm-featured-image {
 	text-align: center;
+}
+.cm-featured-image:not(:last-child) {
 	margin-bottom: 16px;
 }
 .cm-featured-image a {

--- a/style.css
+++ b/style.css
@@ -3080,6 +3080,7 @@ Styles for separating single posts loaded from ajax call.
 
 .cm-featured-image {
 	text-align: center;
+	margin-bottom: 16px;
 }
 .cm-featured-image a {
 	display: block;


### PR DESCRIPTION
Related to themegrill/colormag-pro#327.

`.cm-featured-image` had no `margin-bottom` at all, and `.cm-entry-title` only ever gets a `margin-bottom` by design (like every heading in this theme) — nothing created space between the image and the title that follows it, on both blog cards and single posts.

No existing Customizer setting for this (checked every option file under `inc/customizer/options/content/`) — just a missing default, as the issue suspected.

Added `margin-bottom: length('l-8')` (16px) to `.cm-featured-image`, matching the theme's own spacing scale. Same fix as colormag-pro's PR (byte-identical file, same shared bug): themegrill/colormag-pro#332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

