### PR TITLE
Fix: Footer Menu 1 dropdown could silently fail to save a selection

### DIFF
--- a/inc/customizer/options/footer-builder/footer-menu.php
+++ b/inc/customizer/options/footer-builder/footer-menu.php
@@ -1,6 +1,8 @@
 <?php
 $menus        = wp_get_nav_menus();
-$menu_choices = array();
+$menu_choices = array(
+	'none' => esc_html__( 'None', 'colormag' ),
+);
 
 foreach ( $menus as $menu ) {
 	$menu_choices[ $menu->term_id ] = $menu->name;


### PR DESCRIPTION
## Summary

Fixes [themegrill/colormag-pro#329](https://github.com/themegrill/colormag-pro/issues/329) — Footer Builder's "Menu 1" (Footer Menu) dropdown could visually show a menu as selected while the actual saved setting stayed at its coded default, causing the footer to fall back to a plain page listing instead of showing the intended menu.

## Root cause

`colormag_footer_menu`'s "Select a Menu" control declares `'default' => 'none'`, but its `choices` array only contained real menu term IDs — no entry for `'none'`. Since no `<option>` matched the actual setting value, the browser's native `<select>` silently defaulted to displaying the *first* menu in the list as selected, with zero user interaction and zero change to the underlying setting.

If a user's first action was to open the dropdown, see a menu already looking selected, and publish without picking a different option first, `colormag_footer_menu` was never actually saved — it stayed `"none"`. On the frontend, `wp_nav_menu(['menu' => 'none', 'theme_location' => 'menu-footer'])` can't resolve either the `menu` argument or the `theme_location` (which isn't a registered location when the Header/Footer Builder is active), so it falls through to its `wp_page_menu()` fallback — rendering a page listing instead of the menu the dropdown appeared to show.

Confirmed live via Playwright: with a fresh changeset and the setting at its true default `"none"`, the rendered `<select>` had `selectedIndex: 0` on "Main Menu" purely because no option matched `"none"` — reproducing the reported symptom exactly.

## Fix

Add a `'none' => 'None'` choice to the array (matching the existing convention used elsewhere in this codebase, e.g. `inc/customizer/options/header-and-navigation/primary-menu.php`), so the dropdown can always represent the true saved state and only changes when the user actually picks something.

## Test plan

- [x] Reproduced pre-fix: with `colormag_footer_menu` at its default `"none"`, the rendered dropdown showed the first menu as selected despite the setting being unchanged; footer rendered `wp_list_pages()` fallback markup (`page_item` classes) instead of `wp_nav_menu()` output.
- [x] Applied fix, reloaded with a fresh changeset: dropdown now correctly matches the "None" option when the setting is `"none"`.
- [x] Explicitly selected a real menu via the dropdown, confirmed the setting updates and the footer renders proper `menu-item`/`menu-item-object-page` markup with the correct menu's actual items (including a draft page that `wp_list_pages()` would never show, ruling out the fallback path).
